### PR TITLE
Simplify RemoveAttr API

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -557,22 +557,10 @@ func (e *Element) CreateAttrFull(space, key, value string) *Attr {
 	return &e.Attr[len(e.Attr)-1]
 }
 
-// RemoveElement removes and returns the given attribute. If an equal
-// attribute does not exist, nil is returned.
-func (e *Element) RemoveAttr(attr *Attr) *Attr {
-	for i, a := range e.Attr {
-		if a == *attr {
-			e.Attr = append(e.Attr[0:i], e.Attr[i+1:]...)
-			return attr
-		}
-	}
-	return nil
-}
-
-// RemoveAttrByKey removes and returns the first attribute of the
-// element whose key matches the given key.  If an equal attribute
-// does not exist, nil is returned.
-func (e *Element) RemoveAttrByKey(key string) *Attr {
+// RemoveAttr removes and returns the first attribute of the element whose key
+// matches the given key. If an equal attribute does not exist, nil is
+// returned.
+func (e *Element) RemoveAttr(key string) *Attr {
 	for i, a := range e.Attr {
 		if a.Key == key {
 			e.Attr = append(e.Attr[0:i], e.Attr[i+1:]...)
@@ -582,10 +570,10 @@ func (e *Element) RemoveAttrByKey(key string) *Attr {
 	return nil
 }
 
-// RemoveAttrByKeyFull removes and returns the first attribute of the
-// element whose namespace and key match the given values.  If an
-// equal attibute does not exist, nil is returned.
-func (e *Element) RemoveAttrByKeyFull(space, key string) *Attr {
+// RemoveAttrFull removes and returns the first attribute of the element whose
+// namespace and key match the given values. If an equal attibute does not
+// exist, nil is returned.
+func (e *Element) RemoveAttrFull(space, key string) *Attr {
 	for i, a := range e.Attr {
 		if a.Space == space && a.Key == key {
 			e.Attr = append(e.Attr[0:i], e.Attr[i+1:]...)

--- a/etree_test.go
+++ b/etree_test.go
@@ -20,7 +20,7 @@ func TestDocument(t *testing.T) {
 	store.CreateComment("This is a comment")
 	book := store.CreateElement("book")
 	book.CreateAttrFull("", "lang", "fr")
-	lang := book.CreateAttr("lang", "en")
+	book.CreateAttr("lang", "en")
 	title := book.CreateElementFull("t", "title")
 	title.SetText("Nicholas Nickleby")
 	title.SetText("Great Expectations")
@@ -97,21 +97,12 @@ func TestDocument(t *testing.T) {
 	if book.SelectAttrValueFull("t", "missing", "unknown") != "unknown" {
 		t.Fail()
 	}
-	attr = book.RemoveAttr(lang)
-	if attr != lang {
-		t.Fail()
-	}
-	attr = book.SelectAttr("lang")
-	if attr != nil {
-		t.Fail()
-	}
-	book.CreateAttrFull("", "lang", "fr")
-	attr = book.RemoveAttrByKeyFull("", "lang")
-	if attr.Value != "fr" {
+	attr = book.RemoveAttrFull("", "lang")
+	if attr.Value != "en" {
 		t.Fail()
 	}
 	book.CreateAttr("lang", "de")
-	attr = book.RemoveAttrByKey("lang")
+	attr = book.RemoveAttr("lang")
 	if attr.Value != "de" {
 		t.Fail()
 	}


### PR DESCRIPTION
Remove the initial RemoveAttr method I contributed, it's redundant
and awkward. This allows giving the new RemoveAttrByKey and
RemoveAttrByKeyFull shorter method names.
