### PR TITLE
support canonical xml

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -685,7 +685,11 @@ func (p *ProcInst) dup(parent *Element) Token {
 func (p *ProcInst) writeTo(w *bufio.Writer) {
 	w.WriteString("<?")
 	w.WriteString(p.Target)
-	w.WriteByte(' ')
-	w.WriteString(p.Inst)
-	w.WriteString("?>")
+	if SupportCanonicalXML && p.Inst == "" {
+		w.WriteString("?>")
+	} else {
+		w.WriteByte(' ')
+		w.WriteString(p.Inst)
+		w.WriteString("?>")
+	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -40,9 +40,11 @@ func ExampleDocument_creating() {
 
 // Create an etree Document, add XML entities to it, and serialize it
 // to stdout.
-func ExampleDocument_creatingWithCanonicalSupport() {
-	etree.SupportCanonicalXML = true
+func ExampleDocument_creatingWithNonDefaultWriteSettings() {
 	doc := etree.NewDocument()
+	doc.WriteSettings.EnableExplicitEndTags = true
+	doc.WriteSettings.EnableTextEscapeCodes = false
+	doc.WriteSettings.EnableAttrEscapeCodes = false
 	doc.CreateProcInst("xml-stylesheet", `type="text/xsl" href="style.xsl"`)
 
 	people := doc.CreateElement("People")
@@ -56,7 +58,6 @@ func ExampleDocument_creatingWithCanonicalSupport() {
 
 	doc.Indent(2)
 	doc.WriteTo(os.Stdout)
-	etree.SupportCanonicalXML = false
 	// Output:
 	// <?xml-stylesheet type="text/xsl" href="style.xsl"?>
 	// <People>

--- a/example_test.go
+++ b/example_test.go
@@ -38,6 +38,34 @@ func ExampleDocument_creating() {
 	// </People>
 }
 
+// Create an etree Document, add XML entities to it, and serialize it
+// to stdout.
+func ExampleDocument_creatingWithCanonicalSupport() {
+	etree.SupportCanonicalXML = true
+	doc := etree.NewDocument()
+	doc.CreateProcInst("xml-stylesheet", `type="text/xsl" href="style.xsl"`)
+
+	people := doc.CreateElement("People")
+	people.CreateComment("These are all known people")
+
+	jon := people.CreateElement("Person")
+	jon.CreateAttr("name", "Jon O'Reilly")
+
+	sally := people.CreateElement("Person")
+	sally.CreateAttr("name", "Sally")
+
+	doc.Indent(2)
+	doc.WriteTo(os.Stdout)
+	etree.SupportCanonicalXML = false
+	// Output:
+	// <?xml-stylesheet type="text/xsl" href="style.xsl"?>
+	// <People>
+	//   <!--These are all known people-->
+	//   <Person name="Jon O'Reilly"></Person>
+	//   <Person name="Sally"></Person>
+	// </People>
+}
+
 func ExampleDocument_reading() {
 	doc := etree.NewDocument()
 	if err := doc.ReadFromFile("document.xml"); err != nil {


### PR DESCRIPTION
Thanks for creating this package. Its been very useful and saved me a lot of time.

I'm working on a project that requires canonical XML, so that signatures and digest hashes over the XML doc can be validated.  I've made a couple changes here that should allow me to do that without affecting the default behavior for anyone else.  Specifically, this enables explicit end tags (http://www.w3.org/TR/xml-c14n#Example-SETags), and bypasses the default escaping so that I can implement my own (http://www.w3.org/TR/xml-c14n#Example-Chars).

Let me know if this looks ok, or if you want it structured differently.