### PR TITLE
Update canonical string replacers

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -696,12 +696,16 @@ var xmlReplacerCanonicalText = strings.NewReplacer(
 	"&", "&amp;",
 	"<", "&lt;",
 	">", "&gt;",
+	"\r", "&#xD;",
 )
 
 var xmlReplacerCanonicalAttrVal = strings.NewReplacer(
 	"&", "&amp;",
 	"<", "&lt;",
 	`"`, "&quot;",
+	"\t", "&#x9;",
+	"\n", "&#xA;",
+	"\r", "&#xD;",
 )
 
 // writeTo serializes the attribute to the writer.

--- a/etree_test.go
+++ b/etree_test.go
@@ -173,11 +173,11 @@ func TestWriteSettings(t *testing.T) {
 
 	jon := people.CreateElement("Person")
 	jon.CreateAttr("name", "Jon O'Reilly")
-	jon.SetText("<'\">&")
+	jon.SetText("\r<'\">&")
 
 	sally := people.CreateElement("Person")
 	sally.CreateAttr("name", "Sally")
-	sally.CreateAttr("escape", "<'\">&")
+	sally.CreateAttr("escape", "\r\n\t<'\">&")
 
 	doc.Indent(2)
 	s, err := doc.WriteToString()
@@ -188,8 +188,8 @@ func TestWriteSettings(t *testing.T) {
 	expected := BOM + `<?xml-stylesheet type="text/xsl" href="style.xsl"?>
 <People>
   <!--These are all known people-->
-  <Person name="Jon O'Reilly">&lt;'"&gt;&amp;</Person>
-  <Person name="Sally" escape="&lt;'&quot;>&amp;"></Person>
+  <Person name="Jon O'Reilly">&#xD;&lt;'"&gt;&amp;</Person>
+  <Person name="Sally" escape="&#xD;&#xA;&#x9;&lt;'&quot;>&amp;"></Person>
 </People>
 `
 	checkEq(t, s, expected)


### PR DESCRIPTION
This update is to make the canonical replacers correctly handle additional character references.  See example 3.4 in the spec here: https://www.w3.org/TR/xml-c14n#Example-Chars