### PR TITLE
Path rewrite

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -795,7 +795,7 @@ func (e *Element) FindElement(path string) *Element {
 // FindElementPath returns the first element matched by the XPath-like path
 // string. Returns nil if no element is found using the path.
 func (e *Element) FindElementPath(path Path) *Element {
-	p := newPather()
+	p := &pather{}
 	elements := p.traverse(e, path)
 	if len(elements) > 0 {
 		return elements[0]
@@ -811,7 +811,7 @@ func (e *Element) FindElements(path string) []*Element {
 
 // FindElementsPath returns a slice of elements matched by the Path object.
 func (e *Element) FindElementsPath(path Path) []*Element {
-	p := newPather()
+	p := &pather{}
 	return p.traverse(e, path)
 }
 

--- a/path.go
+++ b/path.go
@@ -5,9 +5,17 @@
 package etree
 
 import (
+	"errors"
+	"reflect"
 	"strconv"
-	"strings"
+	"unicode/utf8"
+	"unsafe"
 )
+
+// ErrPathSyntax is returned when a path has incorrect syntax.
+var ErrPathSyntax = errors.New("etree: invalid path")
+
+const largeListSize = 16
 
 /*
 A Path is a string that represents a search path through an etree starting
@@ -19,11 +27,11 @@ be modified by one or more bracket-enclosed "filters". Selectors are used to
 traverse the etree from element to element, while filters are used to narrow
 the list of candidate elements at each node.
 
-Although etree Path strings are similar to XPath strings
-(https://www.w3.org/TR/1999/REC-xpath-19991116/), they have a more limited set
-of selectors and filtering options.
+Although etree Path strings are structurally and behaviorally similar to XPath
+strings (https://www.w3.org/TR/1999/REC-xpath-19991116/), they have a more
+limited set of selectors and filtering options.
 
-The following selectors are supported by etree Path strings:
+The following selectors are supported by etree paths:
 
     .               Select the current element.
     ..              Select the parent of the current element.
@@ -32,7 +40,7 @@ The following selectors are supported by etree Path strings:
     //              Select all descendants of the current element.
     tag             Select all child elements with a name matching the tag.
 
-The following basic filters are supported by etree Path strings:
+The following basic filters are supported:
 
     [@attrib]       Keep elements with an attribute named attrib.
     [@attrib='val'] Keep elements with an attribute named attrib and value matching val.
@@ -40,7 +48,7 @@ The following basic filters are supported by etree Path strings:
     [tag='val']     Keep elements with a child element named tag and text matching val.
     [n]             Keep the n-th element, where n is a numeric index starting from 1.
 
-The following function filters are also supported:
+The following function-based filters are supported:
 
     [text()]                    Keep elements with non-empty text.
     [text()='val']              Keep elements whose text matches val.
@@ -51,64 +59,62 @@ The following function filters are also supported:
     [namespace-uri()]           Keep elements with non-empty namespace URIs.
     [namespace-uri()='val']     Keep elements whose namespace URI matches val.
 
-Here are some examples of Path strings:
+Below are some examples of etree path strings.
 
-- Select the bookstore child element of the root element:
+Select the bookstore child element of the root element:
     /bookstore
 
-- Beginning from the root element, select the title elements of all
-descendant book elements having a 'category' attribute of 'WEB':
+Beginning from the root element, select the title elements of all descendant
+book elements having a 'category' attribute of 'WEB':
     //book[@category='WEB']/title
 
-- Beginning from the current element, select the first descendant
-book element with a title child element containing the text 'Great
-Expectations':
+Beginning from the current element, select the first descendant book element
+with a title child element containing the text 'Great Expectations':
     .//book[title='Great Expectations'][1]
 
-- Beginning from the current element, select all child elements of
-book elements with an attribute 'language' set to 'english':
+Beginning from the current element, select all child elements of book elements
+with an attribute 'language' set to 'english':
     ./book/*[@language='english']
 
-- Beginning from the current element, select all child elements of
-book elements containing the text 'special':
+Beginning from the current element, select all child elements of book elements
+containing the text 'special':
     ./book/*[text()='special']
 
-- Beginning from the current element, select all descendant book
-elements whose title child element has a 'language' attribute of 'french':
+Beginning from the current element, select all descendant book elements whose
+title child element has a 'language' attribute of 'french':
     .//book/title[@language='french']/..
 
-- Beginning from the current element, select all book elements
+Beginning from the current element, select all descendant book elements
 belonging to the http://www.w3.org/TR/html4/ namespace:
-	.//book[namespace-uri()='http://www.w3.org/TR/html4/']
+    .//book[namespace-uri()='http://www.w3.org/TR/html4/']
 
 */
 type Path struct {
-	segments []segment
+	segments []segment // union of segment results
 }
 
-// ErrPath is returned by path functions when an invalid etree path is provided.
-type ErrPath string
+// CompilePath creates an optimized version of an XPath-like string that can
+// be used to query elements in an element tree.
+func CompilePath(path string) (p Path, err error) {
+	var c compiler
 
-// Error returns the string describing a path error.
-func (err ErrPath) Error() string {
-	return "etree: " + string(err)
-}
-
-// CompilePath creates an optimized version of an XPath-like string that
-// can be used to query elements in an element tree.
-func CompilePath(path string) (Path, error) {
-	var comp compiler
-	segments := comp.parsePath(path)
-	if comp.err != ErrPath("") {
-		return Path{nil}, comp.err
+	toks, err := c.tokenizePath(path)
+	if err != nil {
+		return p, err
 	}
-	return Path{segments}, nil
+
+	err = c.parsePath(&p, toks)
+	if err != nil {
+		return Path{}, err
+	}
+
+	return p, nil
 }
 
 // MustCompilePath creates an optimized version of an XPath-like string that
 // can be used to query elements in an element tree.  Panics if an error
-// occurs.  Use this function to create Paths when you know the path is
-// valid (i.e., if it's hard-coded).
+// occurs.  Use this function to create Paths when you know the path is valid
+// (i.e., if it's hard-coded).
 func MustCompilePath(path string) Path {
 	p, err := CompilePath(path)
 	if err != nil {
@@ -117,169 +123,259 @@ func MustCompilePath(path string) Path {
 	return p
 }
 
-// A segment is a portion of a path between "/" characters.
-// It contains one selector and zero or more [filters].
+/*
+Tokens:
+  /                     sep
+  //                    sep_recurse
+  [                     lbracket
+  ]                     rbracket
+  (                     lparen
+  )                     rparen
+  |                     union
+  =                     equal
+  :                     colon
+  @                     attrib
+  .                     self
+  ..                    parent
+  *                     wildcard
+  '[^']*'               string
+  "[^"]*'               string
+  [a-zA-Z][a-z_A-Z0-9]* identifier
+  -?[0-9][0-9]*         number
+
+Grammar:
+  <path>          ::= <sep>? (<segment> <sep>)* <segment>?
+  <sep>           ::= '/' | '//'
+  <segment>       ::= <segmentExpr> ('|' <segmentExpr>)
+  <segmentExpr>   ::= <selector> <filterWrapper>* | '(' <segment> ')'
+  <selector>      ::= '.' | '..' | '*' | <name>
+  <filterWrapper> ::= '[' <filter> ']'
+  <filter>        ::= <filterExpr> ('|' <filterExpr>)*
+  <filterExpr>    ::= <filterIndex> | <filterAttrib> | <filterChild> | <filterFunc> | '(' <filter> ')'
+  <filterIndex>   ::= number
+  <filterAttrib>  ::= '@' <name> | '@' <name> '=' string
+  <filterChild>   ::= <name> | <name> '=' string
+  <filterFunc>    ::= <name> '(' ')' | <name> '(' ')' '=' string
+  <name>          ::= ident | ident ':' ident
+*/
+
 type segment struct {
+	exprs []segmentExpr // union of all segment expressions
+}
+
+type segmentExpr struct {
 	sel     selector
-	filters []filter
+	filters []filter // filters applied in sequence
 }
 
-func (seg *segment) apply(e *Element, p *pather) {
-	seg.sel.apply(e, p)
-	for _, f := range seg.filters {
-		f.apply(p)
-	}
+type filter struct {
+	exprs []filterExpr // union of all filter expressions
 }
 
-// A selector selects XML elements for consideration by the
-// path traversal.
 type selector interface {
-	apply(e *Element, p *pather)
+	eval(e *Element) candidates
 }
 
-// A filter pares down a list of candidate XML elements based
-// on a path filter in [brackets].
-type filter interface {
-	apply(p *pather)
+type filterExpr interface {
+	eval(e *Element, in candidates) candidates
 }
 
-// A pather is helper object that traverses an element tree using
-// a Path object.  It collects and deduplicates all elements matching
-// the path query.
-type pather struct {
-	queue      fifo
-	results    []*Element
-	inResults  map[*Element]bool
-	candidates []*Element
-	scratch    []*Element // used by filters
+var rootSegment = segment{
+	exprs: []segmentExpr{
+		segmentExpr{
+			sel: &selectRoot{},
+		},
+	},
 }
 
-// A node represents an element and the remaining path segments that
-// should be applied against it by the pather.
-type node struct {
-	e        *Element
-	segments []segment
-}
-
-func newPather() *pather {
-	return &pather{
-		results:    make([]*Element, 0),
-		inResults:  make(map[*Element]bool),
-		candidates: make([]*Element, 0),
-		scratch:    make([]*Element, 0),
-	}
-}
-
-// traverse follows the path from the element e, collecting
-// and then returning all elements that match the path's selectors
-// and filters.
-func (p *pather) traverse(e *Element, path Path) []*Element {
-	for p.queue.add(node{e, path.segments}); p.queue.len() > 0; {
-		p.eval(p.queue.remove().(node))
-	}
-	return p.results
-}
-
-// eval evalutes the current path node by applying the remaining
-// path's selector rules against the node's element.
-func (p *pather) eval(n node) {
-	p.candidates = p.candidates[0:0]
-	seg, remain := n.segments[0], n.segments[1:]
-	seg.apply(n.e, p)
-
-	if len(remain) == 0 {
-		for _, c := range p.candidates {
-			if in := p.inResults[c]; !in {
-				p.inResults[c] = true
-				p.results = append(p.results, c)
-			}
-		}
-	} else {
-		for _, c := range p.candidates {
-			p.queue.add(node{c, remain})
-		}
-	}
+var descendantsSegment = segment{
+	exprs: []segmentExpr{
+		segmentExpr{
+			sel: &selectDescendants{},
+		},
+	},
 }
 
 // A compiler generates a compiled path from a path string.
 type compiler struct {
-	err ErrPath
 }
 
-// parsePath parses an XPath-like string describing a path
-// through an element tree and returns a slice of segment
-// descriptors.
-func (c *compiler) parsePath(path string) []segment {
-	// If path ends with //, fix it
-	if strings.HasSuffix(path, "//") {
-		path = path + "*"
+func (c *compiler) parsePath(p *Path, toks tokens) (err error) {
+	// <path> ::= <sep>? (<segment> <sep>)* <segment>?
+
+	// Check for an absolute path.
+	switch toks.peekID() {
+	case tokSep:
+		p.segments = append(p.segments, rootSegment)
+		toks = toks.consume(1)
+	case tokSepRecurse:
+		p.segments = append(p.segments, rootSegment)
+		p.segments = append(p.segments, descendantsSegment)
+		toks = toks.consume(1)
+	case tokEOL:
+		return ErrPathSyntax
 	}
 
-	var segments []segment
+	// Process remaining segments.
+loop:
+	for len(toks) > 0 {
+		var s segment
+		toks, err = c.parseSegment(&s, toks)
+		if err != nil {
+			return err
+		}
 
-	// Check for an absolute path
-	if strings.HasPrefix(path, "/") {
-		segments = append(segments, segment{new(selectRoot), []filter{}})
-		path = path[1:]
+		p.segments = append(p.segments, s)
+
+		var tok token
+		tok, toks = toks.next()
+		switch tok.id {
+		case tokSep:
+			// do nothing
+		case tokSepRecurse:
+			p.segments = append(p.segments, descendantsSegment)
+		case tokEOL:
+			break loop
+		default:
+			return ErrPathSyntax
+		}
 	}
 
-	// Split path into segments
-	for _, s := range splitPath(path) {
-		segments = append(segments, c.parseSegment(s))
-		if c.err != ErrPath("") {
+	return nil
+}
+
+func (c *compiler) parseSegment(s *segment, toks tokens) (remain tokens, err error) {
+	// <segment> ::= <segmentExpr> ('|' <segmentExpr>)
+
+	// Parse one or more segments.
+	for {
+		toks, err = c.parseSegmentExpr(s, toks)
+		if err != nil {
+			return nil, err
+		}
+
+		if toks.peekID() != tokUnion {
 			break
 		}
+		toks = toks.consume(1)
 	}
-	return segments
+
+	return toks, nil
 }
 
-func splitPath(path string) []string {
-	pieces := make([]string, 0)
-	start := 0
-	inquote := false
-	for i := 0; i+1 <= len(path); i++ {
-		if path[i] == '\'' {
-			inquote = !inquote
-		} else if path[i] == '/' && !inquote {
-			pieces = append(pieces, path[start:i])
-			start = i + 1
+func (c *compiler) parseSegmentExpr(s *segment, toks tokens) (remain tokens, err error) {
+	// <segmentExpr> ::= <selector> <filterWrapper>* | '(' <segment> ')'
+
+	// Check for parentheses.
+	if toks.peekID() == tokLParen {
+		var ss segment
+		toks, err = c.parseSegment(&ss, toks.consume(1))
+		if err != nil {
+			return nil, err
 		}
-	}
-	return append(pieces, path[start:])
-}
 
-// parseSegment parses a path segment between / characters.
-func (c *compiler) parseSegment(path string) segment {
-	pieces := strings.Split(path, "[")
-	seg := segment{
-		sel:     c.parseSelector(pieces[0]),
-		filters: []filter{},
+		s.exprs = append(s.exprs, ss.exprs...)
+
+		var tok token
+		tok, toks = toks.next()
+		if tok.id != tokRParen {
+			return nil, ErrPathSyntax
+		}
+		return toks, nil
 	}
-	for i := 1; i < len(pieces); i++ {
-		fpath := pieces[i]
-		if fpath[len(fpath)-1] != ']' {
-			c.err = ErrPath("path has invalid filter [brackets].")
+
+	// Parse the selector.
+	var e segmentExpr
+	toks, err = c.parseSelector(&e.sel, toks)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse zero or more bracket-wrapped filter expressions.
+	for {
+		if toks.peekID() != tokLBracket {
 			break
 		}
-		seg.filters = append(seg.filters, c.parseFilter(fpath[:len(fpath)-1]))
+
+		var f filter
+		toks, err = c.parseFilter(&f, toks.consume(1))
+		if err != nil {
+			return nil, ErrPathSyntax
+		}
+
+		var tok token
+		tok, toks = toks.next()
+		if tok.id != tokRBracket {
+			return nil, ErrPathSyntax
+		}
+
+		e.filters = append(e.filters, f)
 	}
-	return seg
+
+	s.exprs = append(s.exprs, e)
+	return toks, nil
 }
 
-// parseSelector parses a selector at the start of a path segment.
-func (c *compiler) parseSelector(path string) selector {
-	switch path {
-	case ".":
-		return new(selectSelf)
-	case "..":
-		return new(selectParent)
-	case "*":
-		return new(selectChildren)
-	case "":
-		return new(selectDescendants)
+func (c *compiler) parseSelector(s *selector, toks tokens) (remain tokens, err error) {
+	// <selector> ::= '.' | '..' | '*' | <name>
+
+	switch toks.peekID() {
+	case tokSelf:
+		toks = toks.consume(1)
+		*s = &selectSelf{}
+	case tokParent:
+		toks = toks.consume(1)
+		*s = &selectParent{}
+	case tokChildren:
+		toks = toks.consume(1)
+		*s = &selectChildren{}
+	case tokIdentifier:
+		var sp, name string
+		toks, sp, name, err = c.parseName(toks)
+		if err != nil {
+			return nil, err
+		}
+		*s = &selectChildrenByTag{sp, name}
 	default:
-		return newSelectChildrenByTag(path)
+		return nil, ErrPathSyntax
 	}
+
+	return toks, nil
+}
+
+func (c *compiler) parseName(toks tokens) (remain tokens, sp, name string, err error) {
+	// <name> ::= identifier | identifier ':' identifier
+
+	var tok token
+	tok, toks = toks.next()
+	if toks.peekID() == tokColon {
+		sp = tok.value.toString()
+		tok, toks = toks.consume(1).next()
+		if tok.id != tokIdentifier {
+			return nil, "", "", ErrPathSyntax
+		}
+		return toks, sp, tok.value.toString(), nil
+	}
+	return toks, "", tok.value.toString(), nil
+}
+
+func (c *compiler) parseFilter(fu *filter, toks tokens) (remain tokens, err error) {
+	// <filter> ::= <filterExpr> ('|' <filterExpr>)*
+
+	// Parse one or more filter expressions.
+	for {
+		toks, err = c.parseFilterExpr(fu, toks)
+		if err != nil {
+			return nil, err
+		}
+
+		if toks.peekID() != tokUnion {
+			break
+		}
+		toks = toks.consume(1)
+	}
+
+	return toks, nil
 }
 
 var fnTable = map[string]func(e *Element) string{
@@ -290,292 +386,824 @@ var fnTable = map[string]func(e *Element) string{
 	"text":             (*Element).Text,
 }
 
-// parseFilter parses a path filter contained within [brackets].
-func (c *compiler) parseFilter(path string) filter {
-	if len(path) == 0 {
-		c.err = ErrPath("path contains an empty filter expression.")
-		return nil
-	}
+func (c *compiler) parseFilterExpr(f *filter, toks tokens) (remain tokens, err error) {
+	// <filterExpr> ::= number
+	//                | '@' ident | '@' ident '=' string
+	//                | ident | ident '=' string
+	//                | ident '(' ')' | ident '(' ')' '=' string
+	//                | '(' <filter> ')'
 
-	// Filter contains [@attr='val'], [fn()='val'], or [tag='val']?
-	eqindex := strings.Index(path, "='")
-	if eqindex >= 0 {
-		rindex := nextIndex(path, "'", eqindex+2)
-		if rindex != len(path)-1 {
-			c.err = ErrPath("path has mismatched filter quotes.")
-			return nil
+	switch toks.peekID() {
+	case tokLParen:
+		// '(' <filter> ')'
+		var ff filter
+		toks, err = c.parseFilter(&ff, toks.consume(1))
+		if err != nil {
+			return nil, err
+		}
+		var tok token
+		tok, toks = toks.next()
+		if tok.id != tokRParen {
+			return nil, ErrPathSyntax
+		}
+		f.exprs = append(f.exprs, ff.exprs...)
+
+	case tokNumber:
+		// number
+		var tok token
+		tok, toks = toks.next()
+
+		index, _ := strconv.Atoi(string(tok.value))
+		if index > 0 {
+			index--
+		}
+		f.exprs = append(f.exprs, &filterIndex{index})
+
+	case tokAt:
+		var sp, key string
+		toks, sp, key, err = c.parseName(toks.consume(1))
+		if err != nil {
+			return nil, err
 		}
 
-		key := path[:eqindex]
-		value := path[eqindex+2 : rindex]
-
-		switch {
-		case key[0] == '@':
-			return newFilterAttrVal(key[1:], value)
-		case strings.HasSuffix(key, "()"):
-			name := key[:len(key)-2]
-			if fn, ok := fnTable[name]; ok {
-				return newFilterFuncVal(fn, value)
+		if toks.peekID() == tokEqual {
+			// '@' <name> '=' string
+			var tok token
+			tok, toks = toks.consume(1).next()
+			if tok.id != tokString {
+				return nil, ErrPathSyntax
 			}
-			c.err = ErrPath("path has unknown function " + name)
-			return nil
+			f.exprs = append(f.exprs, &filterAttribValue{sp, key, tok.value.toString()})
+		} else {
+			// '@' <name>
+			f.exprs = append(f.exprs, &filterAttrib{sp, key})
+		}
+
+	case tokIdentifier:
+		var sp, tag string
+		toks, sp, tag, err = c.parseName(toks)
+		if err != nil {
+			return nil, err
+		}
+
+		switch toks.peekID() {
+		case tokEqual:
+			// ident '=' string
+			var tok token
+			tok, toks = toks.consume(1).next()
+			if tok.id != tokString {
+				return nil, ErrPathSyntax
+			}
+			f.exprs = append(f.exprs, &filterChildText{sp, tag, tok.value.toString()})
+
+		case tokLParen:
+			var tok token
+			tok, toks = toks.consume(1).next()
+			if tok.id != tokRParen {
+				return nil, ErrPathSyntax
+			}
+			fn, ok := fnTable[tag]
+			if !ok {
+				return nil, ErrPathSyntax
+			}
+			if toks.peekID() == tokEqual {
+				// ident '(' ')' '=' string
+				tok, toks = toks.consume(1).next()
+				if tok.id != tokString {
+					return nil, ErrPathSyntax
+				}
+				f.exprs = append(f.exprs, &filterByValueFunc{fn, tok.value.toString()})
+			} else {
+				// ident '(' ')'
+				f.exprs = append(f.exprs, &filterByExistsFunc{fn})
+			}
+
 		default:
-			return newFilterChildText(key, value)
+			// ident
+			f.exprs = append(f.exprs, &filterChild{sp, tag})
+		}
+
+	default:
+		return nil, ErrPathSyntax
+	}
+
+	return toks, nil
+}
+
+//
+// pather
+//
+
+// A pather is helper object that traverses an element tree using a Path
+// object.  It collects and deduplicates all elements matching the path query.
+type pather struct {
+}
+
+// A node represents an element and the remaining path segments that should be
+// applied against it by the pather.
+type node struct {
+	e        *Element
+	segments []segment
+}
+
+// A candidates list represents a list of elements that match a selector's or
+// filter's criteria.
+type candidates struct {
+	list  []*Element
+	table map[*Element]bool
+}
+
+func newCandidates() candidates {
+	return candidates{}
+}
+
+func (c *candidates) add(e *Element) {
+	// Lazy create the list of candidate elements.
+	if c.list == nil {
+		c.list = make([]*Element, 0)
+	}
+
+	c.list = append(c.list, e)
+
+	// As a speed optimization, start using a table once the list becomes
+	// large enough.
+	if c.table == nil && len(c.list) >= largeListSize {
+		c.table = make(map[*Element]bool)
+		for _, e := range c.list {
+			c.table[e] = true
 		}
 	}
 
-	// Filter contains [@attr], [N], [tag] or [fn()]
-	switch {
-	case path[0] == '@':
-		return newFilterAttr(path[1:])
-	case strings.HasSuffix(path, "()"):
-		name := path[:len(path)-2]
-		if fn, ok := fnTable[name]; ok {
-			return newFilterFunc(fn)
-		}
-		c.err = ErrPath("path has unknown function " + name)
-		return nil
-	case isInteger(path):
-		pos, _ := strconv.Atoi(path)
-		switch {
-		case pos > 0:
-			return newFilterPos(pos - 1)
-		default:
-			return newFilterPos(pos)
-		}
-	default:
-		return newFilterChild(path)
+	if c.table != nil {
+		c.table[e] = true
 	}
 }
 
-// selectSelf selects the current element into the candidate list.
-type selectSelf struct{}
+func (c *candidates) merge(other candidates) {
+	if other.list == nil {
+		return
+	}
 
-func (s *selectSelf) apply(e *Element, p *pather) {
-	p.candidates = append(p.candidates, e)
+	if c.list == nil {
+		c.list = make([]*Element, 0)
+	}
+
+	if c.table == nil && len(c.list)+len(other.list) >= largeListSize {
+		c.table = make(map[*Element]bool)
+		for _, e := range c.list {
+			c.table[e] = true
+		}
+	}
+
+	if c.table == nil {
+	outer:
+		for _, e := range other.list {
+			for _, ee := range c.list {
+				if e == ee {
+					continue outer
+				}
+			}
+			c.list = append(c.list, e)
+		}
+	} else {
+		for _, e := range other.list {
+			if !c.table[e] {
+				c.table[e] = true
+				c.list = append(c.list, e)
+			}
+		}
+	}
+}
+
+// traverse follows the path from the element e, collecting and then returning
+// all elements that match the path's selectors and filters.
+func (p *pather) traverse(e *Element, path Path) []*Element {
+	out := newCandidates()
+
+	var queue fifo
+	for queue.add(node{e, path.segments}); queue.len() > 0; {
+		n := queue.remove().(node)
+		seg, remain := n.segments[0], n.segments[1:]
+
+		candidates := p.evalSegment(n.e, seg)
+
+		if len(remain) == 0 {
+			out.merge(candidates)
+		} else {
+			for _, e := range candidates.list {
+				queue.add(node{e, remain})
+			}
+		}
+	}
+
+	return out.list
+}
+
+func (p *pather) evalSegment(e *Element, s segment) candidates {
+	out := newCandidates()
+
+	for _, ex := range s.exprs {
+		out.merge(p.evalSegmentExpr(e, ex))
+	}
+
+	return out
+}
+
+func (p *pather) evalSegmentExpr(e *Element, expr segmentExpr) candidates {
+	out := expr.sel.eval(e)
+
+	if len(out.list) > 0 {
+		for _, f := range expr.filters {
+			out = p.evalFilter(e, f, out)
+			if len(out.list) == 0 {
+				break
+			}
+		}
+	}
+
+	return out
+}
+
+func (p *pather) evalFilter(e *Element, f filter, in candidates) candidates {
+	out := newCandidates()
+
+	for _, expr := range f.exprs {
+		out.merge(expr.eval(e, in))
+	}
+
+	return out
 }
 
 // selectRoot selects the element's root node.
-type selectRoot struct{}
+type selectRoot struct {
+}
 
-func (s *selectRoot) apply(e *Element, p *pather) {
+func (s *selectRoot) eval(e *Element) candidates {
 	root := e
 	for root.parent != nil {
 		root = root.parent
 	}
-	p.candidates = append(p.candidates, root)
+	out := newCandidates()
+	out.add(root)
+	return out
+}
+
+// selectSelf selects the current element into the candidate list.
+type selectSelf struct {
+}
+
+func (s *selectSelf) eval(e *Element) candidates {
+	out := newCandidates()
+	out.add(e)
+	return out
 }
 
 // selectParent selects the element's parent into the candidate list.
-type selectParent struct{}
-
-func (s *selectParent) apply(e *Element, p *pather) {
-	if e.parent != nil {
-		p.candidates = append(p.candidates, e.parent)
-	}
+type selectParent struct {
 }
 
-// selectChildren selects the element's child elements into the
-// candidate list.
-type selectChildren struct{}
+func (s *selectParent) eval(e *Element) candidates {
+	out := newCandidates()
 
-func (s *selectChildren) apply(e *Element, p *pather) {
-	for _, c := range e.Child {
-		if c, ok := c.(*Element); ok {
-			p.candidates = append(p.candidates, c)
+	if e.parent != nil {
+		out.add(e.parent)
+	}
+
+	return out
+}
+
+// selectChildren selects the element's child elements into the candidate
+// list.
+type selectChildren struct {
+}
+
+func (s *selectChildren) eval(e *Element) candidates {
+	out := newCandidates()
+
+	for _, child := range e.Child {
+		if child, ok := child.(*Element); ok {
+			out.add(child)
 		}
 	}
+
+	return out
 }
 
-// selectDescendants selects all descendant child elements
-// of the element into the candidate list.
-type selectDescendants struct{}
+// selectChildrenByTag selects into the candidate list all child elements of
+// the element having the specified tag.
+type selectChildrenByTag struct {
+	space string
+	tag   string
+}
 
-func (s *selectDescendants) apply(e *Element, p *pather) {
+func (s *selectChildrenByTag) eval(e *Element) candidates {
+	out := newCandidates()
+
+	for _, ch := range e.Child {
+		if ch, ok := ch.(*Element); ok && spaceMatch(s.space, ch.Space) && s.tag == ch.Tag {
+			out.add(ch)
+		}
+	}
+
+	return out
+}
+
+// selectDescendants selects all descendant child elements of the element into
+// the candidate list.
+type selectDescendants struct {
+}
+
+func (s *selectDescendants) eval(e *Element) candidates {
+	out := newCandidates()
+
 	var queue fifo
 	for queue.add(e); queue.len() > 0; {
 		e := queue.remove().(*Element)
-		p.candidates = append(p.candidates, e)
-		for _, c := range e.Child {
-			if c, ok := c.(*Element); ok {
-				queue.add(c)
+		out.add(e)
+		for _, ch := range e.Child {
+			if ch, ok := ch.(*Element); ok {
+				queue.add(ch)
 			}
 		}
 	}
+
+	return out
 }
 
-// selectChildrenByTag selects into the candidate list all child
-// elements of the element having the specified tag.
-type selectChildrenByTag struct {
-	space, tag string
-}
-
-func newSelectChildrenByTag(path string) *selectChildrenByTag {
-	s, l := spaceDecompose(path)
-	return &selectChildrenByTag{s, l}
-}
-
-func (s *selectChildrenByTag) apply(e *Element, p *pather) {
-	for _, c := range e.Child {
-		if c, ok := c.(*Element); ok && spaceMatch(s.space, c.Space) && s.tag == c.Tag {
-			p.candidates = append(p.candidates, c)
-		}
-	}
-}
-
-// filterPos filters the candidate list, keeping only the
-// candidate at the specified index.
-type filterPos struct {
+// filterIndex filters the candidate list, keeping only the candidate at the
+// specified index.
+type filterIndex struct {
 	index int
 }
 
-func newFilterPos(pos int) *filterPos {
-	return &filterPos{pos}
-}
+func (f *filterIndex) eval(e *Element, in candidates) candidates {
+	out := newCandidates()
 
-func (f *filterPos) apply(p *pather) {
 	if f.index >= 0 {
-		if f.index < len(p.candidates) {
-			p.scratch = append(p.scratch, p.candidates[f.index])
+		if f.index < len(in.list) {
+			out.add(in.list[f.index])
 		}
 	} else {
-		if -f.index <= len(p.candidates) {
-			p.scratch = append(p.scratch, p.candidates[len(p.candidates)+f.index])
+		if -f.index <= len(in.list) {
+			out.add(in.list[len(in.list)+f.index])
 		}
 	}
-	p.candidates, p.scratch = p.scratch, p.candidates[0:0]
+
+	return out
 }
 
-// filterAttr filters the candidate list for elements having
-// the specified attribute.
-type filterAttr struct {
-	space, key string
+// filterAttrib filters the candidate list for elements having the specified
+// attribute.
+type filterAttrib struct {
+	space string
+	key   string
 }
 
-func newFilterAttr(str string) *filterAttr {
-	s, l := spaceDecompose(str)
-	return &filterAttr{s, l}
-}
+func (f *filterAttrib) eval(e *Element, in candidates) candidates {
+	out := newCandidates()
 
-func (f *filterAttr) apply(p *pather) {
-	for _, c := range p.candidates {
-		for _, a := range c.Attr {
+	for _, ch := range in.list {
+		for _, a := range ch.Attr {
 			if spaceMatch(f.space, a.Space) && f.key == a.Key {
-				p.scratch = append(p.scratch, c)
+				out.add(ch)
 				break
 			}
 		}
 	}
-	p.candidates, p.scratch = p.scratch, p.candidates[0:0]
+
+	return out
 }
 
-// filterAttrVal filters the candidate list for elements having
-// the specified attribute with the specified value.
-type filterAttrVal struct {
-	space, key, val string
+// filterAttribValue filters the candidate list for elements having the
+// specified attribute with the specified value.
+type filterAttribValue struct {
+	space string
+	key   string
+	value string
 }
 
-func newFilterAttrVal(str, value string) *filterAttrVal {
-	s, l := spaceDecompose(str)
-	return &filterAttrVal{s, l, value}
-}
+func (f *filterAttribValue) eval(e *Element, in candidates) candidates {
+	out := newCandidates()
 
-func (f *filterAttrVal) apply(p *pather) {
-	for _, c := range p.candidates {
-		for _, a := range c.Attr {
-			if spaceMatch(f.space, a.Space) && f.key == a.Key && f.val == a.Value {
-				p.scratch = append(p.scratch, c)
+	for _, ch := range in.list {
+		for _, a := range ch.Attr {
+			if spaceMatch(f.space, a.Space) && f.key == a.Key && f.value == a.Value {
+				out.add(ch)
 				break
 			}
 		}
 	}
-	p.candidates, p.scratch = p.scratch, p.candidates[0:0]
+
+	return out
 }
 
-// filterFunc filters the candidate list for elements satisfying a custom
-// boolean function.
-type filterFunc struct {
+// filterChild filters the candidate list for elements having a child element
+// with the specified tag.
+type filterChild struct {
+	space string
+	tag   string
+}
+
+func (f *filterChild) eval(e *Element, in candidates) candidates {
+	out := newCandidates()
+
+	for _, ch := range in.list {
+		for _, cc := range ch.Child {
+			if cc, ok := cc.(*Element); ok && spaceMatch(f.space, cc.Space) && f.tag == cc.Tag {
+				out.add(ch)
+			}
+		}
+	}
+
+	return out
+}
+
+// filterChildText filters the candidate list for elements having a child
+// element with the specified tag and text.
+type filterChildText struct {
+	space string
+	tag   string
+	value string
+}
+
+func (f *filterChildText) eval(e *Element, in candidates) candidates {
+	out := newCandidates()
+
+	for _, ch := range in.list {
+		for _, cc := range ch.Child {
+			if cc, ok := cc.(*Element); ok && spaceMatch(f.space, cc.Space) && f.tag == cc.Tag && f.value == cc.Text() {
+				out.add(ch)
+			}
+		}
+	}
+
+	return out
+}
+
+// filterByExistsFunc filters the candidate list for elements a boolean
+// 'existence' function.
+type filterByExistsFunc struct {
 	fn func(e *Element) string
 }
 
-func newFilterFunc(fn func(e *Element) string) *filterFunc {
-	return &filterFunc{fn}
-}
+func (f *filterByExistsFunc) eval(e *Element, in candidates) candidates {
+	out := newCandidates()
 
-func (f *filterFunc) apply(p *pather) {
-	for _, c := range p.candidates {
-		if f.fn(c) != "" {
-			p.scratch = append(p.scratch, c)
+	for _, ch := range in.list {
+		if f.fn(ch) != "" {
+			out.add(ch)
 		}
 	}
-	p.candidates, p.scratch = p.scratch, p.candidates[0:0]
+
+	return out
 }
 
-// filterFuncVal filters the candidate list for elements containing a value
-// matching the result of a custom function.
-type filterFuncVal struct {
+// filterByValueFunc filters the candidate list for elements containing a
+// value matching the result of a custom function.
+type filterByValueFunc struct {
 	fn  func(e *Element) string
 	val string
 }
 
-func newFilterFuncVal(fn func(e *Element) string, value string) *filterFuncVal {
-	return &filterFuncVal{fn, value}
-}
+func (f *filterByValueFunc) eval(e *Element, in candidates) candidates {
+	out := newCandidates()
 
-func (f *filterFuncVal) apply(p *pather) {
-	for _, c := range p.candidates {
-		if f.fn(c) == f.val {
-			p.scratch = append(p.scratch, c)
+	for _, ch := range in.list {
+		if f.fn(ch) == f.val {
+			out.add(ch)
 		}
 	}
-	p.candidates, p.scratch = p.scratch, p.candidates[0:0]
+
+	return out
 }
 
-// filterChild filters the candidate list for elements having
-// a child element with the specified tag.
-type filterChild struct {
-	space, tag string
+//
+// tokenizer
+//
+
+type tokenID uint8
+
+const (
+	tokNil tokenID = iota
+	tokSep
+	tokSepRecurse
+	tokLBracket
+	tokRBracket
+	tokLParen
+	tokRParen
+	tokUnion
+	tokEqual
+	tokColon
+	tokAt
+	tokSelf
+	tokParent
+	tokChildren
+	tokString
+	tokIdentifier
+	tokNumber
+	tokEOL
+)
+
+const (
+	lNil uint8 = iota
+	lIde       // identifer
+	lLbr       // lbracket
+	lRbr       // rbracket
+	lLpa       // lparen
+	lRpa       // rparen
+	lWld       // wildcard
+	lSep       // separator
+	lNum       // numeric
+	lUni       // union
+	lSub       // minus
+	lDot       // dot
+	lQuo       // quote
+	lAtt       // attrib (@)
+	lEqu       // equal
+	lCol       // colon
+)
+
+const (
+	xIdentStart = 1 << 6
+	xIdentChar  = 1 << 7
+	x0          = 0
+	x1          = xIdentChar
+	x2          = xIdentChar | xIdentStart
+)
+
+type token struct {
+	id    tokenID
+	value tstring
 }
 
-func newFilterChild(str string) *filterChild {
-	s, l := spaceDecompose(str)
-	return &filterChild{s, l}
+// A table mapping the first character of a lexeme to token lookup data.
+var lexHint0 = [128]uint8{
+	x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, // 0..7
+	x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, // 8..15
+	x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, // 16..23
+	x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, // 24..31
+	x0 | lNil, x0 | lNil, x0 | lQuo, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lNil, x0 | lQuo, // 32..39
+	x0 | lLpa, x0 | lRpa, x0 | lWld, x0 | lNil, x0 | lNil, x1 | lSub, x1 | lDot, x0 | lSep, // 40..47
+	x1 | lNum, x1 | lNum, x1 | lNum, x1 | lNum, x1 | lNum, x1 | lNum, x1 | lNum, x1 | lNum, // 48..55
+	x1 | lNum, x1 | lNum, x0 | lCol, x0 | lNil, x0 | lNil, x0 | lEqu, x0 | lNil, x0 | lNil, // 56..63
+	x0 | lAtt, x0 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, // 64..71
+	x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, // 72..79
+	x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, // 80..87
+	x2 | lIde, x2 | lIde, x2 | lIde, x0 | lLbr, x0 | lNil, x0 | lRbr, x0 | lNil, x2 | lIde, // 88..95
+	x0 | lNil, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, // 96..103
+	x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, // 104..111
+	x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, x2 | lIde, // 112..119
+	x2 | lIde, x2 | lIde, x2 | lIde, x0 | lNil, x0 | lUni, x0 | lNil, x0 | lNil, x0 | lNil, // 120..127
 }
 
-func (f *filterChild) apply(p *pather) {
-	for _, c := range p.candidates {
-		for _, cc := range c.Child {
-			if cc, ok := cc.(*Element); ok &&
-				spaceMatch(f.space, cc.Space) &&
-				f.tag == cc.Tag {
-				p.scratch = append(p.scratch, c)
-			}
+type lexemeData struct {
+	tokID    tokenID
+	tokenize func(c *compiler, s tstring) (t token, remain tstring, err error)
+}
+
+var lexToToken = []lexemeData{
+	/*lNil*/ {tokID: tokNil},
+	/*lIde*/ {tokenize: (*compiler).tokenizeIdentifier},
+	/*lLBr*/ {tokID: tokLBracket},
+	/*lRBr*/ {tokID: tokRBracket},
+	/*lLpa*/ {tokID: tokLParen},
+	/*lRpa*/ {tokID: tokRParen},
+	/*lWld*/ {tokID: tokChildren},
+	/*lSep*/ {tokenize: (*compiler).tokenizeSlash},
+	/*lNum*/ {tokenize: (*compiler).tokenizeNumber},
+	/*lOra*/ {tokID: tokUnion},
+	/*lSub*/ {tokenize: (*compiler).tokenizeMinus},
+	/*lDot*/ {tokenize: (*compiler).tokenizeDot},
+	/*lQuo*/ {tokenize: (*compiler).tokenizeQuote},
+	/*lAtt*/ {tokID: tokAt},
+	/*lEqu*/ {tokID: tokEqual},
+	/*lCol*/ {tokID: tokColon},
+}
+
+func (c *compiler) tokenizePath(path string) (toks tokens, err error) {
+	s := tstring(path).consumeWhitespace()
+	toks = make(tokens, 0)
+
+	for len(s) > 0 {
+		tok, remain, err := c.tokenizeLexeme(s)
+		if err != nil {
+			return nil, err
+		}
+		if tok.id == tokNil {
+			return nil, ErrPathSyntax
+		}
+
+		toks = append(toks, tok)
+
+		s = remain.consumeWhitespace()
+	}
+
+	return toks, nil
+}
+
+func (c *compiler) tokenizeLexeme(s tstring) (t token, remain tstring, err error) {
+	if len(s) == 0 {
+		return token{}, s, nil
+	}
+
+	r, sz := s.nextRune()
+
+	// Use the first character of the string to look up lexeme data.
+	var ldata lexemeData
+	switch {
+	case r < 128:
+		ldata = lexToToken[lexHint0[r]&0x3f]
+	case identifierStart(r):
+		ldata = lexToToken[lIde]
+	default:
+		return token{}, s, ErrPathSyntax
+	}
+
+	// If the lexeme consists of only one character, we're done.
+	if ldata.tokenize == nil {
+		return token{ldata.tokID, ""}, s.consume(sz), nil
+	}
+
+	// Parse the rest of the lexeme.
+	return ldata.tokenize(c, s)
+}
+
+func (c *compiler) tokenizeIdentifier(s tstring) (t token, remain tstring, err error) {
+	var ident tstring
+	ident, remain = s.consumeWhile(identifier)
+	return token{tokIdentifier, ident}, remain, nil
+}
+
+func (c *compiler) tokenizeSlash(s tstring) (t token, remain tstring, err error) {
+	if len(s) > 1 && s[1] == '/' {
+		return token{tokSepRecurse, ""}, s.consume(2), nil
+	}
+	return token{tokSep, ""}, s.consume(1), nil
+}
+
+func (c *compiler) tokenizeNumber(s tstring) (t token, remain tstring, err error) {
+	var num tstring
+	num, remain = s.consumeWhile(decimal)
+	return token{tokNumber, num}, remain, nil
+}
+
+func (c *compiler) tokenizeMinus(s tstring) (t token, remain tstring, err error) {
+	var num tstring
+	num, remain = s.consume(1).consumeWhile(decimal)
+	if len(num) == 0 {
+		return token{}, s, ErrPathSyntax
+	}
+	num = s[:len(num)+1]
+	return token{tokNumber, num}, remain, nil
+}
+
+func (c *compiler) tokenizeDot(s tstring) (t token, remain tstring, err error) {
+	if len(s) > 1 && s[1] == '.' {
+		return token{tokParent, ""}, s.consume(2), nil
+	}
+	return token{tokSelf, ""}, s.consume(1), nil
+}
+
+func (c *compiler) tokenizeQuote(s tstring) (t token, remain tstring, err error) {
+	quot := rune(s[0])
+	s = s.consume(1)
+
+	for i, r := range s {
+		if r == quot {
+			s, remain = s[:i], s[i+1:]
+			return token{tokString, s}, remain, nil
 		}
 	}
-	p.candidates, p.scratch = p.scratch, p.candidates[0:0]
+
+	return token{}, s, ErrPathSyntax
 }
 
-// filterChildText filters the candidate list for elements having
-// a child element with the specified tag and text.
-type filterChildText struct {
-	space, tag, text string
+//
+// tokens
+//
+
+type tokens []token
+
+func (t tokens) consume(n int) tokens {
+	return t[n:]
 }
 
-func newFilterChildText(str, text string) *filterChildText {
-	s, l := spaceDecompose(str)
-	return &filterChildText{s, l, text}
-}
-
-func (f *filterChildText) apply(p *pather) {
-	for _, c := range p.candidates {
-		for _, cc := range c.Child {
-			if cc, ok := cc.(*Element); ok &&
-				spaceMatch(f.space, cc.Space) &&
-				f.tag == cc.Tag &&
-				f.text == cc.Text() {
-				p.scratch = append(p.scratch, c)
-			}
-		}
+func (t tokens) peekID() tokenID {
+	if len(t) == 0 {
+		return tokEOL
 	}
-	p.candidates, p.scratch = p.scratch, p.candidates[0:0]
+	return t[0].id
+}
+
+func (t tokens) next() (tok token, remain tokens) {
+	if len(t) == 0 {
+		return token{id: tokEOL}, t
+	}
+	return t[0], t[1:]
+}
+
+//
+// tstring
+//
+
+type tstring string
+
+func (s tstring) consume(n int) tstring {
+	return s[n:]
+}
+
+func (s tstring) consumeWhitespace() tstring {
+	return s.consume(s.scanWhile(whitespace))
+}
+
+func (s tstring) scanWhile(fn func(r rune) bool) int {
+	i := 0
+	var r rune
+	for _, r = range s {
+		if !fn(r) {
+			break
+		}
+		i++
+	}
+	return i
+}
+
+func (s tstring) consumeWhile(fn func(r rune) bool) (consumed, remain tstring) {
+	i := s.scanWhile(fn)
+	return s[:i], s[i:]
+}
+
+func (s tstring) nextRune() (r rune, sz int) {
+	return utf8.DecodeRuneInString(s.toString())
+}
+
+func (s tstring) toString() string {
+	// Convert the tstring to a string without making a copy.
+	var out string
+	src := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	dst := (*reflect.StringHeader)(unsafe.Pointer(&out))
+	dst.Len = src.Len
+	dst.Data = src.Data
+	return out
+}
+
+func whitespace(r rune) bool {
+	return r == ' ' || r == '\t'
+}
+
+func decimal(r rune) bool {
+	return (r >= '0' && r <= '9')
+}
+
+func identifierStart(r rune) bool {
+	if r < 128 {
+		return (lexHint0[r] & xIdentStart) != 0
+	}
+
+	switch {
+	case r >= 0xc0 && r <= 0xd6:
+		return true
+	case r >= 0xd8 && r <= 0xf6:
+		return true
+	case r >= 0xf8 && r <= 0x2ff:
+		return true
+	case r >= 0x370 && r <= 0x37d:
+		return true
+	case r >= 0x37f && r <= 0x1fff:
+		return true
+	case r >= 0x200c && r <= 0x200d:
+		return true
+	case r >= 0x2070 && r <= 0x218f:
+		return true
+	case r >= 0x2c00 && r <= 0x2fef:
+		return true
+	case r >= 0x3001 && r <= 0xd7ff:
+		return true
+	case r >= 0xf900 && r <= 0xfdcf:
+		return true
+	case r >= 0xfdf0 && r <= 0xfffd:
+		return true
+	default:
+		return false
+	}
+}
+
+func identifier(r rune) bool {
+	// "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
+	switch {
+	case r < 128:
+		return (lexHint0[r] & xIdentChar) != 0
+	case identifierStart(r):
+		return true
+	case r == 0xb7:
+		return true
+	case r >= 0x300 && r <= 0x36f:
+		return true
+	case r >= 0x300 && r <= 0x36f:
+		return true
+	case r >= 0x203f && r <= 0x2040:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
Path system rewritten. It now supports the '|' operator for selectors and filters.  It also supports parentheses and strips unnecessary whitespace.