### PR TITLE
Support for CDATA serialisation

### DIFF
--- a/etree_test.go
+++ b/etree_test.go
@@ -32,6 +32,9 @@ func TestDocument(t *testing.T) {
 	title.SetText("Great Expectations")
 	author := book.CreateElement("author")
 	author.CreateCharData("Charles Dickens")
+	review := book.CreateElement("review")
+	review.CreateCharData("<<< Will be replaced").Cdata = true
+	review.SetText(">>> Excellent book")
 	doc.IndentTabs()
 
 	// Serialize the document to a string
@@ -49,6 +52,7 @@ func TestDocument(t *testing.T) {
 	<book lang="en">
 		<t:title>Great Expectations</t:title>
 		<author>Charles Dickens</author>
+		<review><![CDATA[>>> Excellent book]]></review>
 	</book>
 </store>
 `
@@ -61,13 +65,16 @@ func TestDocument(t *testing.T) {
 	if len(store.ChildElements()) != 1 || len(store.Child) != 7 {
 		t.Error("etree: incorrect tree structure")
 	}
-	if len(book.ChildElements()) != 2 || len(book.Attr) != 1 || len(book.Child) != 5 {
+	if len(book.ChildElements()) != 3 || len(book.Attr) != 1 || len(book.Child) != 7 {
 		t.Error("etree: incorrect tree structure")
 	}
 	if len(title.ChildElements()) != 0 || len(title.Child) != 1 || len(title.Attr) != 0 {
 		t.Error("etree: incorrect tree structure")
 	}
 	if len(author.ChildElements()) != 0 || len(author.Child) != 1 || len(author.Attr) != 0 {
+		t.Error("etree: incorrect tree structure")
+	}
+	if len(review.ChildElements()) != 0 || len(review.Child) != 1 || len(review.Attr) != 0 {
 		t.Error("etree: incorrect tree structure")
 	}
 	if book.parent != store || store.parent != &doc.Element || doc.parent != nil {
@@ -131,6 +138,10 @@ func TestDocument(t *testing.T) {
 	}
 	element = book.SelectElement("title")
 	if element != nil {
+		t.Error("etree: incorrect SelectElement result")
+	}
+	element = book.SelectElement("review")
+	if element != review || element.Text() != ">>> Excellent book" || len(element.Attr) != 0 {
 		t.Error("etree: incorrect SelectElement result")
 	}
 }


### PR DESCRIPTION
Hi,

For my "project", I needed to have CDATA support. The API I am using (confluence) is sometimes return CDATA and expects CDATA in some nodes when called.
I did not find a very satisfactory way of handling this, as it seems the standard Go Unmarshaller won't tell you if the text it is returning is coming from a CDATA or not. But, for my case, I can manage it as I know the nodes that are supposed to contain CDATA, I just need the encoding part of it.
I thought I would propose my implementation, even though it is not of the quality I would like it to be.

This one is based on adding a bool flag in the CharData struct, I have another one using a new type. Both are equivalent in terms of result, it is just a matter of taste.

Let me know. I need it so will keep it in my fork but I can understand if it is does not make its way to the official repo.

Gabriel