### PR TITLE
CDATA serialisation support

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -22,6 +22,12 @@ const (
 	NoIndent = -1
 )
 
+var (
+	cdataStart  = []byte("<![CDATA[")
+	cdataEnd    = []byte("]]>")
+	cdataEscape = []byte("]]]]><![CDATA[>")
+)
+
 // ErrXML is returned when XML parsing fails due to incorrect formatting.
 var ErrXML = errors.New("etree: invalid XML format")
 
@@ -109,6 +115,7 @@ type Attr struct {
 // CharData represents character data within XML.
 type CharData struct {
 	Data       string
+	plain      bool
 	parent     *Element
 	whitespace bool
 }
@@ -336,7 +343,7 @@ func (e *Element) SetText(text string) {
 			return
 		}
 	}
-	cd := newCharData(text, false, e)
+	cd := newCharData(text, false, false, e)
 	copy(e.Child[1:], e.Child[0:])
 	e.Child[0] = cd
 }
@@ -428,7 +435,7 @@ func (e *Element) readFrom(ri io.Reader, settings ReadSettings) (n int64, err er
 			stack.pop()
 		case xml.CharData:
 			data := string(t)
-			newCharData(data, isWhitespace(data), top)
+			newCharData(data, isWhitespace(data), false, top)
 		case xml.Comment:
 			newComment(string(t), top)
 		case xml.Directive:
@@ -642,7 +649,7 @@ func (e *Element) indent(depth int, indent indentFunc) {
 		_, isCharData = c.(*CharData)
 		if !isCharData {
 			if !firstNonCharData || depth > 0 {
-				newCharData(indent(depth), true, e)
+				newCharData(indent(depth), true, false, e)
 			}
 			firstNonCharData = false
 		}
@@ -658,7 +665,7 @@ func (e *Element) indent(depth int, indent indentFunc) {
 	// Insert CR+indent before the last child.
 	if !isCharData {
 		if !firstNonCharData || depth > 0 {
-			newCharData(indent(depth-1), true, e)
+			newCharData(indent(depth-1), true, false, e)
 		}
 	}
 }
@@ -840,16 +847,23 @@ func (a *Attr) writeTo(w *bufio.Writer, s *WriteSettings) {
 
 // NewCharData creates a parentless XML character data entity.
 func NewCharData(data string) *CharData {
-	return newCharData(data, false, nil)
+	return newCharData(data, false, false, nil)
+}
+
+// NewTextData creates a parentless XML character data entity that will be encoded into
+// a CDATA.
+func NewTextData(data string) *CharData {
+	return newCharData(data, false, true, nil)
 }
 
 // newCharData creates an XML character data entity and binds it to a parent
 // element. If parent is nil, the CharData token remains unbound.
-func newCharData(data string, whitespace bool, parent *Element) *CharData {
+func newCharData(data string, whitespace bool, plain bool, parent *Element) *CharData {
 	c := &CharData{
 		Data:       data,
 		whitespace: whitespace,
 		parent:     parent,
+		plain:      plain,
 	}
 	if parent != nil {
 		parent.addChild(c)
@@ -860,7 +874,13 @@ func newCharData(data string, whitespace bool, parent *Element) *CharData {
 // CreateCharData creates an XML character data entity and adds it as a child
 // of element e.
 func (e *Element) CreateCharData(data string) *CharData {
-	return newCharData(data, false, e)
+	return newCharData(data, false, false, e)
+}
+
+// CreateTextData creates an XML character data entity that will be encoded into
+// a CDATA and adds it as a child of element e.
+func (e *Element) CreateTextData(data string) *CharData {
+	return newCharData(data, false, true, e)
 }
 
 // dup duplicates the character data.
@@ -885,13 +905,19 @@ func (c *CharData) setParent(parent *Element) {
 
 // writeTo serializes the character data entity to the writer.
 func (c *CharData) writeTo(w *bufio.Writer, s *WriteSettings) {
-	var m escapeMode
-	if s.CanonicalText {
-		m = escapeCanonicalText
+	if c.plain {
+		w.Write(cdataStart)
+		w.WriteString(c.Data)
+		w.Write(cdataEnd)
 	} else {
-		m = escapeNormal
+		var m escapeMode
+		if s.CanonicalText {
+			m = escapeCanonicalText
+		} else {
+			m = escapeNormal
+		}
+		escapeString(w, c.Data, m)
 	}
-	escapeString(w, c.Data, m)
 }
 
 // NewComment creates a parentless XML comment.

--- a/etree_test.go
+++ b/etree_test.go
@@ -15,6 +15,39 @@ func checkEq(t *testing.T, got, want string) {
 	}
 }
 
+func TestCharAndTextElements(t *testing.T) {
+	doc := NewDocument()
+	root := doc.CreateElement("root")
+	root.CreateCharData("This ")
+	root.CreateTextData("is ")
+	e1 := NewCharData("a ")
+	e2 := NewTextData("text ")
+	root.AddChild(e1)
+	root.AddChild(e2)
+	root.CreateCharData("Element!!")
+	doc.IndentTabs()
+
+	s, err := doc.WriteToString()
+	if err != nil {
+		t.Error("etree: failed to serialize document")
+	}
+
+	// Make sure the serialized XML matches expectation.
+	expected := `<root>This <![CDATA[is ]]>a <![CDATA[text ]]>Element!!</root>
+`
+	checkEq(t, s, expected)
+
+	// Check we can parse the output
+	err = doc.ReadFromString(s)
+	if err != nil {
+		t.Fatal("etree: incorrect ReadFromString result")
+	}
+	if doc.Root().Text() != "This is a text Element!!" {
+		// The Golang XML decoder merges all the Text data into a single text
+		t.Error("etree: invalid structure")
+	}
+}
+
 func TestDocument(t *testing.T) {
 	// Create a document
 	doc := NewDocument()
@@ -32,6 +65,9 @@ func TestDocument(t *testing.T) {
 	title.SetText("Great Expectations")
 	author := book.CreateElement("author")
 	author.CreateCharData("Charles Dickens")
+	review := book.CreateElement("review")
+	review.CreateTextData("<<< Will be replaced")
+	review.SetText(">>> Excellent book")
 	doc.IndentTabs()
 
 	// Serialize the document to a string
@@ -49,6 +85,7 @@ func TestDocument(t *testing.T) {
 	<book lang="en">
 		<t:title>Great Expectations</t:title>
 		<author>Charles Dickens</author>
+		<review><![CDATA[>>> Excellent book]]></review>
 	</book>
 </store>
 `
@@ -61,13 +98,16 @@ func TestDocument(t *testing.T) {
 	if len(store.ChildElements()) != 1 || len(store.Child) != 7 {
 		t.Error("etree: incorrect tree structure")
 	}
-	if len(book.ChildElements()) != 2 || len(book.Attr) != 1 || len(book.Child) != 5 {
+	if len(book.ChildElements()) != 3 || len(book.Attr) != 1 || len(book.Child) != 7 {
 		t.Error("etree: incorrect tree structure")
 	}
 	if len(title.ChildElements()) != 0 || len(title.Child) != 1 || len(title.Attr) != 0 {
 		t.Error("etree: incorrect tree structure")
 	}
 	if len(author.ChildElements()) != 0 || len(author.Child) != 1 || len(author.Attr) != 0 {
+		t.Error("etree: incorrect tree structure")
+	}
+	if len(review.ChildElements()) != 0 || len(review.Child) != 1 || len(review.Attr) != 0 {
 		t.Error("etree: incorrect tree structure")
 	}
 	if book.parent != store || store.parent != &doc.Element || doc.parent != nil {
@@ -131,6 +171,10 @@ func TestDocument(t *testing.T) {
 	}
 	element = book.SelectElement("title")
 	if element != nil {
+		t.Error("etree: incorrect SelectElement result")
+	}
+	element = book.SelectElement("review")
+	if element != review || element.Text() != ">>> Excellent book" || len(element.Attr) != 0 {
 		t.Error("etree: incorrect SelectElement result")
 	}
 }


### PR DESCRIPTION
Hi,

For my "project", I needed to have CDATA support. The API I am using (confluence) is sometimes return CDATA and expects CDATA in some nodes when called.
I did not find a very satisfactory way of handling this, as it seems the standard Go Unmarshaller won't tell you if the text it is returning is coming from a CDATA or not. But, for my case, I can manage it as I know the nodes that are supposed to contain CDATA, I just need the encoding part of it.
I thought I would propose my implementation, even though it is not of the quality I would like it to be.

This one is based on using a new type, I have another one adding a bool flag in the CharData struct. Both are equivalent in terms of result, it is just a matter of taste.

Let me know. I need it so will keep it in my fork but I can understand if it is does not make its way to the official repo.

Gabriel