### PR TITLE
Add handling of xmlns namespaces

### DIFF
--- a/etree_test.go
+++ b/etree_test.go
@@ -614,3 +614,47 @@ func TestCharsetReaderEncoding(t *testing.T) {
 		}
 	}
 }
+
+func TestNamespace(t *testing.T) {
+	testdoc := `
+<N:root xmlns:N="name">
+    <N:key>value1</N:key>
+    <N:root2 xmlns:N="name2">
+        <N:key2>value2</N:key2>
+    </N:root2>
+    <N:key3 N:v="1">value1</N:key3>
+    <root3 xmlns="name3">
+    </root3>
+</N:root>
+`
+	doc := NewDocument()
+	err := doc.ReadFromString(testdoc)
+	if err != nil {
+		t.Fatal("etree ReadFromString: " + err.Error())
+	}
+
+	root := doc.ChildElements()[0]
+	checkEq(t, root.Tag, "root")
+	checkEq(t, root.FullSpace, "name")
+
+	key := root.ChildElements()[0]
+	checkEq(t, key.Tag, "key")
+	checkEq(t, key.FullSpace, "name")
+
+	root2 := root.ChildElements()[1]
+	checkEq(t, root2.Tag, "root2")
+	checkEq(t, root2.FullSpace, "name2")
+
+	key2 := root2.ChildElements()[0]
+	checkEq(t, key2.Tag, "key2")
+	checkEq(t, key2.FullSpace, "name2")
+
+	key3 := root.ChildElements()[2]
+	checkEq(t, key3.Tag, "key3")
+	checkEq(t, key3.FullSpace, "name")
+	checkEq(t, key3.Attr[0].FullSpace, "name")
+
+	root3 := root.ChildElements()[3]
+	checkEq(t, root3.Tag, "root3")
+	checkEq(t, root3.FullSpace, "name3")
+}

--- a/helpers.go
+++ b/helpers.go
@@ -140,13 +140,18 @@ func spaceMatch(a, b string) bool {
 }
 
 // spaceDecompose breaks a namespace:tag identifier at the ':'
-// and returns the two parts.
+// or {namespace}tag identifier and returns the two parts.
 func spaceDecompose(str string) (space, key string) {
-	colon := strings.IndexByte(str, ':')
-	if colon == -1 {
-		return "", str
+	if str[0] == '{' {
+		rB := strings.IndexByte(str, '}')
+		return str[1:rB], str[rB+1:]
+	} else {
+		colon := strings.IndexByte(str, ':')
+		if colon == -1 {
+			return "", str
+		}
+		return str[:colon], str[colon+1:]
 	}
-	return str[:colon], str[colon+1:]
 }
 
 // Strings used by crIndent

--- a/path.go
+++ b/path.go
@@ -373,7 +373,7 @@ func newSelectChildrenByTag(path string) *selectChildrenByTag {
 
 func (s *selectChildrenByTag) apply(e *Element, p *pather) {
 	for _, c := range e.Child {
-		if c, ok := c.(*Element); ok && spaceMatch(s.space, c.Space) && s.tag == c.Tag {
+		if c, ok := c.(*Element); ok && (spaceMatch(s.space, c.Space) || spaceMatch(s.space, c.FullSpace)) && s.tag == c.Tag {
 			p.candidates = append(p.candidates, c)
 		}
 	}
@@ -416,7 +416,7 @@ func newFilterAttr(str string) *filterAttr {
 func (f *filterAttr) apply(p *pather) {
 	for _, c := range p.candidates {
 		for _, a := range c.Attr {
-			if spaceMatch(f.space, a.Space) && f.key == a.Key {
+			if (spaceMatch(f.space, a.Space) || spaceMatch(f.space, a.FullSpace)) && f.key == a.Key {
 				p.scratch = append(p.scratch, c)
 				break
 			}
@@ -439,7 +439,7 @@ func newFilterAttrVal(str, value string) *filterAttrVal {
 func (f *filterAttrVal) apply(p *pather) {
 	for _, c := range p.candidates {
 		for _, a := range c.Attr {
-			if spaceMatch(f.space, a.Space) && f.key == a.Key && f.val == a.Value {
+			if (spaceMatch(f.space, a.Space) || spaceMatch(f.space, a.FullSpace)) && f.key == a.Key && f.val == a.Value {
 				p.scratch = append(p.scratch, c)
 				break
 			}
@@ -498,7 +498,7 @@ func (f *filterChild) apply(p *pather) {
 	for _, c := range p.candidates {
 		for _, cc := range c.Child {
 			if cc, ok := cc.(*Element); ok &&
-				spaceMatch(f.space, cc.Space) &&
+				(spaceMatch(f.space, cc.Space) || spaceMatch(f.space, cc.FullSpace)) &&
 				f.tag == cc.Tag {
 				p.scratch = append(p.scratch, c)
 			}
@@ -522,7 +522,7 @@ func (f *filterChildText) apply(p *pather) {
 	for _, c := range p.candidates {
 		for _, cc := range c.Child {
 			if cc, ok := cc.(*Element); ok &&
-				spaceMatch(f.space, cc.Space) &&
+				(spaceMatch(f.space, cc.Space) || spaceMatch(f.space, cc.FullSpace)) &&
 				f.tag == cc.Tag &&
 				f.text == cc.Text() {
 				p.scratch = append(p.scratch, c)


### PR DESCRIPTION
When querying in xml fragments like this

```xml
<root xmlns:N="namespace">
    <N:element2>v</N:element2>
</root>
```

It is somewhat necessary to specify the full namespace name with tag like `namespace:element2` since the `N` abbreviation can be arbitrarily changed by the user.

Therefore, this pull request added `FullSpace` to `Element` to represent the full namespace name. It also allows tag query using syntax like `{namespace}name` in methods like `FindElements`, `SelectElement` to support complex namespace like urls. 