### PR TITLE
Namespace uri support

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -391,6 +391,16 @@ func (e *Element) findDefaultNamespaceURI() string {
 	return e.parent.findDefaultNamespaceURI()
 }
 
+// hasText returns true if the element has character data immediately
+// folllowing the element's opening tag.
+func (e *Element) hasText() bool {
+	if len(e.Child) == 0 {
+		return false
+	}
+	_, ok := e.Child[0].(*CharData)
+	return ok
+}
+
 // Text returns all character data immediately following the element's opening
 // tag.
 func (e *Element) Text() string {

--- a/etree_test.go
+++ b/etree_test.go
@@ -946,3 +946,90 @@ func TestAttrParent(t *testing.T) {
 		checkElementEq(t, root.Attr[i].Element(), root)
 	}
 }
+
+func TestDefaultNamespaceURI(t *testing.T) {
+	s := `
+<root xmlns="http://root.example.com" a="foo">
+	<child1 xmlns="http://child.example.com" a="foo">
+		<grandchild1 xmlns="http://grandchild.example.com" a="foo">
+		</grandchild1>
+		<grandchild2 a="foo">
+			<greatgrandchild1 a="foo"/>
+		</grandchild2>
+	</child1>
+	<child2 a="foo"/>
+</root>`
+
+	doc := NewDocument()
+	err := doc.ReadFromString(s)
+	if err != nil {
+		t.Error("etree: failed to parse document")
+	}
+
+	root := doc.SelectElement("root")
+	child1 := root.SelectElement("child1")
+	child2 := root.SelectElement("child2")
+	grandchild1 := child1.SelectElement("grandchild1")
+	grandchild2 := child1.SelectElement("grandchild2")
+	greatgrandchild1 := grandchild2.SelectElement("greatgrandchild1")
+
+	checkStrEq(t, doc.NamespaceURI(), "")
+	checkStrEq(t, root.NamespaceURI(), "http://root.example.com")
+	checkStrEq(t, child1.NamespaceURI(), "http://child.example.com")
+	checkStrEq(t, child2.NamespaceURI(), "http://root.example.com")
+	checkStrEq(t, grandchild1.NamespaceURI(), "http://grandchild.example.com")
+	checkStrEq(t, grandchild2.NamespaceURI(), "http://child.example.com")
+	checkStrEq(t, greatgrandchild1.NamespaceURI(), "http://child.example.com")
+
+	checkStrEq(t, root.Attr[0].NamespaceURI(), "http://root.example.com")
+	checkStrEq(t, child1.Attr[0].NamespaceURI(), "http://child.example.com")
+	checkStrEq(t, child2.Attr[0].NamespaceURI(), "http://root.example.com")
+	checkStrEq(t, grandchild1.Attr[0].NamespaceURI(), "http://grandchild.example.com")
+	checkStrEq(t, grandchild2.Attr[0].NamespaceURI(), "http://child.example.com")
+	checkStrEq(t, greatgrandchild1.Attr[0].NamespaceURI(), "http://child.example.com")
+}
+
+func TestLocalNamespaceURI(t *testing.T) {
+	s := `
+<a:root xmlns:a="http://root.example.com">
+	<b:child1 xmlns:b="http://child.example.com">
+		<c:grandchild1 xmlns:c="http://grandchild.example.com"/>
+		<b:grandchild2>
+			<a:greatgrandchild1/>
+		</b:grandchild2>
+		<a:grandchild3/>
+		<grandchild4/>
+	</b:child1>
+	<a:child2>
+	</a:child2>
+	<child3>
+	</child3>
+</a:root>`
+
+	doc := NewDocument()
+	err := doc.ReadFromString(s)
+	if err != nil {
+		t.Error("etree: failed to parse document")
+	}
+
+	root := doc.SelectElement("root")
+	child1 := root.SelectElement("child1")
+	child2 := root.SelectElement("child2")
+	child3 := root.SelectElement("child3")
+	grandchild1 := child1.SelectElement("grandchild1")
+	grandchild2 := child1.SelectElement("grandchild2")
+	grandchild3 := child1.SelectElement("grandchild3")
+	grandchild4 := child1.SelectElement("grandchild4")
+	greatgrandchild1 := grandchild2.SelectElement("greatgrandchild1")
+
+	checkStrEq(t, doc.NamespaceURI(), "")
+	checkStrEq(t, root.NamespaceURI(), "http://root.example.com")
+	checkStrEq(t, child1.NamespaceURI(), "http://child.example.com")
+	checkStrEq(t, child2.NamespaceURI(), "http://root.example.com")
+	checkStrEq(t, child3.NamespaceURI(), "")
+	checkStrEq(t, grandchild1.NamespaceURI(), "http://grandchild.example.com")
+	checkStrEq(t, grandchild2.NamespaceURI(), "http://child.example.com")
+	checkStrEq(t, grandchild3.NamespaceURI(), "http://root.example.com")
+	checkStrEq(t, grandchild4.NamespaceURI(), "")
+	checkStrEq(t, greatgrandchild1.NamespaceURI(), "http://root.example.com")
+}

--- a/etree_test.go
+++ b/etree_test.go
@@ -987,6 +987,31 @@ func TestDefaultNamespaceURI(t *testing.T) {
 	checkStrEq(t, grandchild1.Attr[0].NamespaceURI(), "http://grandchild.example.com")
 	checkStrEq(t, grandchild2.Attr[0].NamespaceURI(), "http://child.example.com")
 	checkStrEq(t, greatgrandchild1.Attr[0].NamespaceURI(), "http://child.example.com")
+
+	f := doc.FindElements("//*[namespace-uri()='http://root.example.com']")
+	if len(f) != 2 || f[0] != root || f[1] != child2 {
+		t.Error("etree: failed namespace-uri test")
+	}
+
+	f = doc.FindElements("//*[namespace-uri()='http://child.example.com']")
+	if len(f) != 3 || f[0] != child1 || f[1] != grandchild2 || f[2] != greatgrandchild1 {
+		t.Error("etree: failed namespace-uri test")
+	}
+
+	f = doc.FindElements("//*[namespace-uri()='http://grandchild.example.com']")
+	if len(f) != 1 || f[0] != grandchild1 {
+		t.Error("etree: failed namespace-uri test")
+	}
+
+	f = doc.FindElements("//*[namespace-uri()='']")
+	if len(f) != 0 {
+		t.Error("etree: failed namespace-uri test")
+	}
+
+	f = doc.FindElements("//*[namespace-uri()='foo']")
+	if len(f) != 0 {
+		t.Error("etree: failed namespace-uri test")
+	}
 }
 
 func TestLocalNamespaceURI(t *testing.T) {
@@ -1032,4 +1057,29 @@ func TestLocalNamespaceURI(t *testing.T) {
 	checkStrEq(t, grandchild3.NamespaceURI(), "http://root.example.com")
 	checkStrEq(t, grandchild4.NamespaceURI(), "")
 	checkStrEq(t, greatgrandchild1.NamespaceURI(), "http://root.example.com")
+
+	f := doc.FindElements("//*[namespace-uri()='http://root.example.com']")
+	if len(f) != 4 || f[0] != root || f[1] != child2 || f[2] != grandchild3 || f[3] != greatgrandchild1 {
+		t.Error("etree: failed namespace-uri test")
+	}
+
+	f = doc.FindElements("//*[namespace-uri()='http://child.example.com']")
+	if len(f) != 2 || f[0] != child1 || f[1] != grandchild2 {
+		t.Error("etree: failed namespace-uri test")
+	}
+
+	f = doc.FindElements("//*[namespace-uri()='http://grandchild.example.com']")
+	if len(f) != 1 || f[0] != grandchild1 {
+		t.Error("etree: failed namespace-uri test")
+	}
+
+	f = doc.FindElements("//*[namespace-uri()='']")
+	if len(f) != 2 || f[0] != child3 || f[1] != grandchild4 {
+		t.Error("etree: failed namespace-uri test")
+	}
+
+	f = doc.FindElements("//*[namespace-uri()='foo']")
+	if len(f) != 0 {
+		t.Error("etree: failed namespace-uri test")
+	}
 }

--- a/etree_test.go
+++ b/etree_test.go
@@ -32,6 +32,13 @@ func checkIntEq(t *testing.T, got, want int) {
 	}
 }
 
+func checkElementEq(t *testing.T, got, want *Element) {
+	t.Helper()
+	if got != want {
+		t.Errorf("etree: unexpected element. Got: %v. Wanted: %v.\n", got, want)
+	}
+}
+
 func checkDocEq(t *testing.T, doc *Document, expected string) {
 	t.Helper()
 	doc.Indent(NoIndent)
@@ -911,4 +918,31 @@ func TestSetTail(t *testing.T) {
 	checkStrEq(t, child.Tail(), "")
 	checkIntEq(t, len(root.Child), 1)
 	checkIntEq(t, len(child.Child), 1)
+}
+
+func TestAttrParent(t *testing.T) {
+	doc := NewDocument()
+	root := doc.CreateElement("root")
+	attr1 := root.CreateAttr("bar", "1")
+	attr2 := root.CreateAttr("qux", "2")
+
+	checkIntEq(t, len(root.Attr), 2)
+	checkElementEq(t, attr1.Element(), root)
+	checkElementEq(t, attr2.Element(), root)
+
+	attr1 = root.RemoveAttr("bar")
+	attr2 = root.RemoveAttr("qux")
+	checkElementEq(t, attr1.Element(), nil)
+	checkElementEq(t, attr2.Element(), nil)
+
+	s := `<root a="1" b="2" c="3" d="4"/>`
+	err := doc.ReadFromString(s)
+	if err != nil {
+		t.Error("etree: failed to parse document")
+	}
+
+	root = doc.SelectElement("root")
+	for i := range root.Attr {
+		checkElementEq(t, root.Attr[i].Element(), root)
+	}
 }

--- a/path.go
+++ b/path.go
@@ -17,22 +17,28 @@ similar to XPath strings, they have a more limited set of selectors and
 filtering options. The following selectors and filters are supported by etree
 paths:
 
-    .               Select the current element.
-    ..              Select the parent of the current element.
-    *               Select all child elements of the current element.
-    /               Select the root element when used at the start of a path.
-    //              Select all descendants of the current element. If used at
-                      the start of a path, select all descendants of the root.
-    tag             Select all child elements with the given tag.
-    [#]             Select the element of the given index (1-based,
-                      negative starts from the end).
-    [@attrib]       Select all elements with the given attribute.
-    [@attrib='val'] Select all elements with the given attribute set to val.
-    [tag]           Select all elements with a child element named tag.
-    [tag='val']     Select all elements with a child element named tag
-                      and text matching val.
-    [text()]        Select all elements with non-empty text.
-    [text()='val']  Select all elements whose text matches val.
+    .                        Select the current element.
+    ..                       Select the parent of the current element.
+    *                        Select all child elements of the current element.
+    /                        Select the root element when used at the start of
+                               a path.
+    //                       Select all descendants of the current element. If
+                               used at the start of a path, select all
+                               descendants of the root.
+    tag                      Select all child elements with the given tag.
+    [#]                      Select the element of the given index (1-based,
+                               negative starts from the end).
+    [@attrib]                Select all elements with the given attribute.
+    [@attrib='val']          Select all elements with the given attribute set
+                               to val.
+    [tag]                    Select all elements with a child element named
+                               tag.
+    [tag='val']              Select all elements with a child element named
+                               tag and text matching val.
+    [text()]                 Select all elements with non-empty text.
+    [text()='val']           Select all elements whose text matches val.
+    [namespace-uri()='val']  Select all elements whose namespace URI matches
+                               val.
 
 Examples:
 
@@ -260,6 +266,14 @@ func (c *compiler) parseSelector(path string) selector {
 	}
 }
 
+var fnTable = map[string]struct {
+	hasFn     func(e *Element) bool
+	compareFn func(e *Element) string
+}{
+	"text":          {(*Element).hasText, (*Element).Text},
+	"namespace-uri": {nil, (*Element).NamespaceURI},
+}
+
 // parseFilter parses a path filter contained within [brackets].
 func (c *compiler) parseFilter(path string) filter {
 	if len(path) == 0 {
@@ -267,7 +281,7 @@ func (c *compiler) parseFilter(path string) filter {
 		return nil
 	}
 
-	// Filter contains [@attr='val'], [text()='val'], or [tag='val']?
+	// Filter contains [@attr='val'], [fn()='val'], or [tag='val']?
 	eqindex := strings.Index(path, "='")
 	if eqindex >= 0 {
 		rindex := nextIndex(path, "'", eqindex+2)
@@ -275,22 +289,38 @@ func (c *compiler) parseFilter(path string) filter {
 			c.err = ErrPath("path has mismatched filter quotes.")
 			return nil
 		}
+
+		key := path[:eqindex]
+		value := path[eqindex+2 : rindex]
+
 		switch {
-		case path[0] == '@':
-			return newFilterAttrVal(path[1:eqindex], path[eqindex+2:rindex])
-		case strings.HasPrefix(path, "text()"):
-			return newFilterTextVal(path[eqindex+2 : rindex])
+		case key[0] == '@':
+			return newFilterAttrVal(key[1:], value)
+		case strings.HasSuffix(key, "()"):
+			fn := key[:len(key)-2]
+			if t, ok := fnTable[fn]; ok && t.compareFn != nil {
+				return newFilterFuncVal(t.compareFn, value)
+			} else {
+				c.err = ErrPath("path has unknown function " + fn)
+				return nil
+			}
 		default:
-			return newFilterChildText(path[:eqindex], path[eqindex+2:rindex])
+			return newFilterChildText(key, value)
 		}
 	}
 
-	// Filter contains [@attr], [N], [tag] or [text()]
+	// Filter contains [@attr], [N], [tag] or [fn()]
 	switch {
 	case path[0] == '@':
 		return newFilterAttr(path[1:])
-	case path == "text()":
-		return newFilterText()
+	case strings.HasSuffix(path, "()"):
+		fn := path[:len(path)-2]
+		if t, ok := fnTable[fn]; ok && t.hasFn != nil {
+			return newFilterFunc(t.hasFn)
+		} else {
+			c.err = ErrPath("path has unknown function " + fn)
+			return nil
+		}
 	case isInteger(path):
 		pos, _ := strconv.Atoi(path)
 		switch {
@@ -448,35 +478,39 @@ func (f *filterAttrVal) apply(p *pather) {
 	p.candidates, p.scratch = p.scratch, p.candidates[0:0]
 }
 
-// filterText filters the candidate list for elements having text.
-type filterText struct{}
-
-func newFilterText() *filterText {
-	return &filterText{}
+// filterFunc filters the candidate list for elements satisfying a custom
+// boolean function.
+type filterFunc struct {
+	fn func(e *Element) bool
 }
 
-func (f *filterText) apply(p *pather) {
+func newFilterFunc(fn func(e *Element) bool) *filterFunc {
+	return &filterFunc{fn}
+}
+
+func (f *filterFunc) apply(p *pather) {
 	for _, c := range p.candidates {
-		if c.Text() != "" {
+		if f.fn(c) {
 			p.scratch = append(p.scratch, c)
 		}
 	}
 	p.candidates, p.scratch = p.scratch, p.candidates[0:0]
 }
 
-// filterTextVal filters the candidate list for elements having
-// text equal to the specified value.
-type filterTextVal struct {
+// filterFuncVal filters the candidate list for elements containing a value
+// matching the result of a custom function.
+type filterFuncVal struct {
+	fn  func(e *Element) string
 	val string
 }
 
-func newFilterTextVal(value string) *filterTextVal {
-	return &filterTextVal{value}
+func newFilterFuncVal(fn func(e *Element) string, value string) *filterFuncVal {
+	return &filterFuncVal{fn, value}
 }
 
-func (f *filterTextVal) apply(p *pather) {
+func (f *filterFuncVal) apply(p *pather) {
 	for _, c := range p.candidates {
-		if c.Text() == f.val {
+		if f.fn(c) == f.val {
 			p.scratch = append(p.scratch, c)
 		}
 	}

--- a/path.go
+++ b/path.go
@@ -267,8 +267,8 @@ func (c *compiler) parseSelector(path string) selector {
 }
 
 var fnTable = map[string]struct {
-	hasFn     func(e *Element) bool
-	compareFn func(e *Element) string
+	hasFn    func(e *Element) bool
+	getValFn func(e *Element) string
 }{
 	"text":          {(*Element).hasText, (*Element).Text},
 	"namespace-uri": {nil, (*Element).NamespaceURI},
@@ -298,8 +298,8 @@ func (c *compiler) parseFilter(path string) filter {
 			return newFilterAttrVal(key[1:], value)
 		case strings.HasSuffix(key, "()"):
 			fn := key[:len(key)-2]
-			if t, ok := fnTable[fn]; ok && t.compareFn != nil {
-				return newFilterFuncVal(t.compareFn, value)
+			if t, ok := fnTable[fn]; ok && t.getValFn != nil {
+				return newFilterFuncVal(t.getValFn, value)
 			} else {
 				c.err = ErrPath("path has unknown function " + fn)
 				return nil


### PR DESCRIPTION
Add methods making it easier to deal with XML namespace URIs.

`Element` and `Attr` now have `NamespaceURI()` methods, which return the full URI of the namespace containing them.

Path queries now support the `namespace-uri()` filter function, making it possible to search for elements belonging to a specific namespace URI.

Attributes now track the element they belong to. This can be queried through the `Attr`'s `Element()` method.