### PR TITLE
Implement new method IsEquivalent for Element type

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -1470,30 +1470,30 @@ func (e *Element) CreateProcInst(target, inst string) *ProcInst {
 // indicates if both elements are equivalent.
 func (e *Element) IsEquivalent(e2 *Element) (equals bool) {
 	if e != nil && e2 != nil {
-		elemChilds1 := e.ChildElements()
-		elemChilds2 := e2.ChildElements()
+		children1 := e.ChildElements()
+		children2 := e2.ChildElements()
 
-		if elemChilds1 == nil && elemChilds2 == nil {
+		if children1 == nil && children2 == nil {
 			return true
 		}
-		if (elemChilds1 == nil && elemChilds2 != nil) || (elemChilds1 != nil && elemChilds2 == nil) {
+		if (children1 == nil && children2 != nil) || (children1 != nil && children2 == nil) {
 			return false
 		}
-		if len(elemChilds1) != len(elemChilds2) {
+		if len(children1) != len(children2) {
 			return false
 		}
 
-		for i, child := range elemChilds1 {
-			secondChild := elemChilds2[i]
+		for i, child := range children1 {
+			secondChild := children2[i]
 			equals = child.IsEquivalent(secondChild)
 			if !equals {
 				return false
 			}
 		}
 
-		for i, elem := range elemChilds1 {
-			secondChild := elemChilds2[i]
-			if elem.Text() != secondChild.Text() || len(elem.Attr) != len(secondChild.Attr) {
+		for i, elem := range children1 {
+			secondChild := children2[i]
+			if strings.TrimSpace(elem.Text()) != strings.TrimSpace(secondChild.Text()) || len(elem.Attr) != len(secondChild.Attr) {
 				return false
 			}
 

--- a/etree_test.go
+++ b/etree_test.go
@@ -86,42 +86,31 @@ func TestElementIsEquivalent(t *testing.T) {
 	s := `<store>
 	<book lang="en">
 		<title>Great Expectations</title>
-		<author>Charles Dickens</author>
-		<id>0</id>
-			<level1>
-			<level2>
-				<level3>
-					<level4>
-						<level5>
-							<level6>FirstBook</level6>
-						</level5>
-					</level4>
-				</level3>
-			</level2>
-		</level1>	
-	</book>
-	<book lang="en">
-		<title>Oliver Twist</title>
-		<author>Charles Dickens</author>
-		<id>1</id>
 		<level1>
 			<level2>
-				<level3>
-					<level4>
-						<level5>
-							<level6>SecondBook</level6>
-						</level5>
-					</level4>
-				</level3>
 			</level2>
-		</level1>	
+		</level1>
+		<author>Charles Dickens</author>
+	</book>
+</store>`
+
+	s2 := `<store>
+	<book lang="en">
+		<title>Great Expectations</title>
+		<level1>
+			<level2>
+
+			</level2>
+		</level1>
+		<author>Charles Dickens</author>
 	</book>
 </store>`
 
 	doc := newDocumentFromString(t, s)
+	doc2 := newDocumentFromString(t, s2)
 
 	e1 := doc.FindElement("./")
-	e2 := doc.FindElement("./")
+	e2 := doc2.FindElement("./")
 
 	b := e1.IsEquivalent(e2)
 
@@ -129,42 +118,18 @@ func TestElementIsEquivalent(t *testing.T) {
 		t.Errorf("etree: IsEquivalent should have returned %v but it was %v",true, b)
 	}
 
-	s2 := `<store>
+	s2 = `<store>
 	<book lang="en">
 		<title>Great Expectations</title>
-		<author>Charles Dickens</author>
-		<id>0</id>
-			<level1>
+		<level1 attr="randomAttribute">
 			<level2>
-				<level3>
-					<level4 attr="randomAttrValue">
-						<level5>
-							<level6>FirstBook</level6>
-						</level5>
-					</level4>
-				</level3>
 			</level2>
-		</level1>	
-	</book>
-	<book lang="en">
-		<title>Oliver Twist</title>
+		</level1>
 		<author>Charles Dickens</author>
-		<id>1</id>
-		<level1>
-			<level2>
-				<level3>
-					<level4>
-						<level5>
-							<level6>SecondBook</level6>
-						</level5>
-					</level4>
-				</level3>
-			</level2>
-		</level1>	
 	</book>
 </store>`
 
-	doc2 := newDocumentFromString(t, s2)
+	doc2 = newDocumentFromString(t, s2)
 
 	e2 = doc2.FindElement("./")
 

--- a/etree_test.go
+++ b/etree_test.go
@@ -81,6 +81,101 @@ func checkIndexes(t *testing.T, e *Element) {
 	}
 }
 
+func TestElementIsEquivalent(t *testing.T) {
+
+	s := `<store>
+	<book lang="en">
+		<title>Great Expectations</title>
+		<author>Charles Dickens</author>
+		<id>0</id>
+			<level1>
+			<level2>
+				<level3>
+					<level4>
+						<level5>
+							<level6>FirstBook</level6>
+						</level5>
+					</level4>
+				</level3>
+			</level2>
+		</level1>	
+	</book>
+	<book lang="en">
+		<title>Oliver Twist</title>
+		<author>Charles Dickens</author>
+		<id>1</id>
+		<level1>
+			<level2>
+				<level3>
+					<level4>
+						<level5>
+							<level6>SecondBook</level6>
+						</level5>
+					</level4>
+				</level3>
+			</level2>
+		</level1>	
+	</book>
+</store>`
+
+	doc := newDocumentFromString(t, s)
+
+	e1 := doc.FindElement("./")
+	e2 := doc.FindElement("./")
+
+	b := e1.IsEquivalent(e2)
+
+	if b != true {
+		t.Errorf("etree: IsEquivalent should have returned %v but it was %v",true, b)
+	}
+
+	s2 := `<store>
+	<book lang="en">
+		<title>Great Expectations</title>
+		<author>Charles Dickens</author>
+		<id>0</id>
+			<level1>
+			<level2>
+				<level3>
+					<level4 attr="randomAttrValue">
+						<level5>
+							<level6>FirstBook</level6>
+						</level5>
+					</level4>
+				</level3>
+			</level2>
+		</level1>	
+	</book>
+	<book lang="en">
+		<title>Oliver Twist</title>
+		<author>Charles Dickens</author>
+		<id>1</id>
+		<level1>
+			<level2>
+				<level3>
+					<level4>
+						<level5>
+							<level6>SecondBook</level6>
+						</level5>
+					</level4>
+				</level3>
+			</level2>
+		</level1>	
+	</book>
+</store>`
+
+	doc2 := newDocumentFromString(t, s2)
+
+	e2 = doc2.FindElement("./")
+
+	b = e1.IsEquivalent(e2)
+
+	if b != false {
+		t.Errorf("etree: IsEquivalent should have returned %v but it was %v",false, b)
+	}
+}
+
+
 func TestDocument(t *testing.T) {
 	// Create a document
 	doc := NewDocument()


### PR DESCRIPTION
# New method IsEquivalent for Element type.

## Description
As detailed in the Issue https://github.com/beevik/etree/issues/90 , we have worked in a method to perform a DeepEquals between two elements that has been useful for our team, so we wanted to share it with all the users of this fantastic go module.

## Details
* IsEquivalent is a recursive method that enters as deep as possible over all the etree.Element of our etree.Document that represents a XML file.
* Once there are no more levels, it analyzes the attributes and text inside the XML nodes till the end. If any of those levels is not exactly the same for e and e2, the method returns false.
* Otherwise, the method returns true.

## Tests
- [x] New TestElementIsEquivalent unit test implemented with a couple of cases.


## Additional info
* We have disccused about the possibility to have options like Whitespace ignoring and Attributes order, however according to the XML spec https://www.w3.org/TR/REC-xml/ neither the attribute order nor the whitespaces are something to worry about so I did not applied it. 
* However, the developer that uses this go mod may want to take any of this things into account, in that case we could implement another method or refine this one, I'm open to both options.


Thanks,

Adolfo Rodriguez
