### PR TITLE
expose WriteTo for tokens, define the needed writer interface

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -89,6 +89,14 @@ type WriteSettings struct {
 	UseCRLF bool
 }
 
+// XMLWriter is a Writer that also has convenience methods for writing
+// strings an single bytes.
+type XMLWriter interface {
+	io.StringWriter
+	io.ByteWriter
+	io.Writer
+}
+
 // newWriteSettings creates a default WriteSettings record.
 func newWriteSettings() WriteSettings {
 	return WriteSettings{
@@ -110,10 +118,10 @@ func (s *WriteSettings) dup() WriteSettings {
 type Token interface {
 	Parent() *Element
 	Index() int
+	WriteTo(w XMLWriter, s *WriteSettings)
 	dup(parent *Element) Token
 	setParent(parent *Element)
 	setIndex(index int)
-	writeTo(w *bufio.Writer, s *WriteSettings)
 }
 
 // A Document is a container holding a complete XML tree.
@@ -291,7 +299,7 @@ func (d *Document) WriteTo(w io.Writer) (n int64, err error) {
 	cw := newCountWriter(w)
 	b := bufio.NewWriter(cw)
 	for _, c := range d.Child {
-		c.writeTo(b, &d.WriteSettings)
+		c.WriteTo(b, &d.WriteSettings)
 	}
 	err, n = b.Flush(), cw.bytes
 	return
@@ -1036,18 +1044,18 @@ func (e *Element) setIndex(index int) {
 	e.index = index
 }
 
-// writeTo serializes the element to the writer w.
-func (e *Element) writeTo(w *bufio.Writer, s *WriteSettings) {
+// WriteTo serializes the element to the writer w.
+func (e *Element) WriteTo(w XMLWriter, s *WriteSettings) {
 	w.WriteByte('<')
 	w.WriteString(e.FullTag())
 	for _, a := range e.Attr {
 		w.WriteByte(' ')
-		a.writeTo(w, s)
+		a.WriteTo(w, s)
 	}
 	if len(e.Child) > 0 {
 		w.WriteByte('>')
 		for _, c := range e.Child {
-			c.writeTo(w, s)
+			c.WriteTo(w, s)
 		}
 		w.Write([]byte{'<', '/'})
 		w.WriteString(e.FullTag())
@@ -1164,8 +1172,8 @@ func (a *Attr) NamespaceURI() string {
 	return a.element.findLocalNamespaceURI(a.Space)
 }
 
-// writeTo serializes the attribute to the writer.
-func (a *Attr) writeTo(w *bufio.Writer, s *WriteSettings) {
+// WriteTo serializes the attribute to the writer.
+func (a *Attr) WriteTo(w XMLWriter, s *WriteSettings) {
 	w.WriteString(a.FullKey())
 	w.WriteString(`="`)
 	var m escapeMode
@@ -1293,8 +1301,8 @@ func (c *CharData) setIndex(index int) {
 	c.index = index
 }
 
-// writeTo serializes character data to the writer.
-func (c *CharData) writeTo(w *bufio.Writer, s *WriteSettings) {
+// WriteTo serializes character data to the writer.
+func (c *CharData) WriteTo(w XMLWriter, s *WriteSettings) {
 	if c.IsCData() {
 		w.WriteString(`<![CDATA[`)
 		w.WriteString(c.Data)
@@ -1366,8 +1374,8 @@ func (c *Comment) setIndex(index int) {
 	c.index = index
 }
 
-// writeTo serialies the comment to the writer.
-func (c *Comment) writeTo(w *bufio.Writer, s *WriteSettings) {
+// WriteTo serialies the comment to the writer.
+func (c *Comment) WriteTo(w XMLWriter, s *WriteSettings) {
 	w.WriteString("<!--")
 	w.WriteString(c.Data)
 	w.WriteString("-->")
@@ -1431,8 +1439,8 @@ func (d *Directive) setIndex(index int) {
 	d.index = index
 }
 
-// writeTo serializes the XML directive to the writer.
-func (d *Directive) writeTo(w *bufio.Writer, s *WriteSettings) {
+// WriteTo serializes the XML directive to the writer.
+func (d *Directive) WriteTo(w XMLWriter, s *WriteSettings) {
 	w.WriteString("<!")
 	w.WriteString(d.Data)
 	w.WriteString(">")
@@ -1499,8 +1507,8 @@ func (p *ProcInst) setIndex(index int) {
 	p.index = index
 }
 
-// writeTo serializes the processing instruction to the writer.
-func (p *ProcInst) writeTo(w *bufio.Writer, s *WriteSettings) {
+// WriteTo serializes the processing instruction to the writer.
+func (p *ProcInst) WriteTo(w XMLWriter, s *WriteSettings) {
 	w.WriteString("<?")
 	w.WriteString(p.Target)
 	if p.Inst != "" {

--- a/helpers.go
+++ b/helpers.go
@@ -5,7 +5,6 @@
 package etree
 
 import (
-	"bufio"
 	"io"
 	"strings"
 	"unicode/utf8"
@@ -211,7 +210,7 @@ const (
 )
 
 // escapeString writes an escaped version of a string to the writer.
-func escapeString(w *bufio.Writer, s string, m escapeMode) {
+func escapeString(w XMLWriter, s string, m escapeMode) {
 	var esc []byte
 	last := 0
 	for i := 0; i < len(s); {


### PR DESCRIPTION
This makes it possible to write XML fragments without having to copy elements to a separate document.

Also satisfies the InnerXML use-case from https://github.com/beevik/etree/issues/71

```
var innerXML bytes.Buffer
var writeSettings etree.WriteSetting

for _, child := range element.Child {
	child.WriteTo(&innerXML, &writeSettings)
}
```

In my actual use-case I just passed in `&doc.WriteSettings`, but there might also be a legitimate need to write out fragments with other settings. So I find a parameter preferrable to using the settings of a hidden associated document.