### PR TITLE
Fix empty file parsing

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -23,8 +23,12 @@ const (
 	NoIndent = -1
 )
 
-// ErrXML is returned when XML parsing fails due to incorrect formatting.
-var ErrXML = errors.New("etree: invalid XML format")
+var (
+	// ErrXML is returned when XML parsing fails due to incorrect formatting.
+	ErrXML = errors.New("etree: invalid XML format")
+	// ErrEmptyFile is returned when the XML parsing encounters an empty XML file.
+	ErrEmptyFile = errors.New("etree: empty XML file")
+)
 
 // ReadSettings determine the default behavior of the Document's ReadFrom*
 // methods.
@@ -269,8 +273,14 @@ func (d *Document) ReadFromFile(filepath string) error {
 		return err
 	}
 	defer f.Close()
-	_, err = d.ReadFrom(f)
-	return err
+	nr, err := d.ReadFrom(f)
+	if err != nil {
+		return err
+	}
+	if nr == 0 {
+		return ErrEmptyFile
+	}
+	return nil
 }
 
 // ReadFromBytes reads XML from the byte slice 'b' into the this document.

--- a/etree_test.go
+++ b/etree_test.go
@@ -7,6 +7,8 @@ package etree
 import (
 	"encoding/xml"
 	"io"
+	"os"
+	"path"
 	"strings"
 	"testing"
 )
@@ -1135,4 +1137,21 @@ func TestWhitespace(t *testing.T) {
 
 	cd.SetData("")
 	checkBoolEq(t, cd.IsWhitespace(), true)
+}
+
+func TestReadEmptyXML(t *testing.T) {
+	tempdir := t.TempDir()
+	emptyFile := path.Join(tempdir, "empty.xml")
+
+	f, err := os.Create(emptyFile)
+	if err != nil {
+		t.Fatal("failed to create empty file")
+	}
+	f.Close()
+
+	doc := NewDocument()
+	err = doc.ReadFromFile(emptyFile)
+	if err == nil {
+		t.Error("etree: expected error because empty XML file parsed")
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/beevik/etree
 
-go 1.12
+go 1.15


### PR DESCRIPTION
ReadFromFile() currently returns no errors if a file that is read in is
empty. This leads to nil pointer dereferences when accessing the
Document.