### PR TITLE
selection for processing instructions added

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -803,6 +803,30 @@ func (e *Element) SelectElements(tag string) []*Element {
 	return elements
 }
 
+// SelectProcInst returns the first processing instruction with the given 'target'
+// (i.e., name). The function returns nil if no processing instruction
+// matching the target is found.
+func (e *Element) SelectProcInst(target string) *ProcInst {
+	for _, t := range e.Child {
+		if c, ok := t.(*ProcInst); ok && target == c.Target {
+			return c
+		}
+	}
+	return nil
+}
+
+// SelectProcInsts returns a slice of all processing instructions
+// with the given 'target' (i.e., name).
+func (e *Element) SelectProcInsts(target string) []*ProcInst {
+	var elements []*ProcInst
+	for _, t := range e.Child {
+		if c, ok := t.(*ProcInst); ok && target == c.Target {
+			elements = append(elements, c)
+		}
+	}
+	return elements
+}
+
 // FindElement returns the first element matched by the XPath-like 'path'
 // string. The function returns nil if no child element is found using the
 // path. It panics if an invalid path string is supplied.

--- a/etree.go
+++ b/etree.go
@@ -766,6 +766,17 @@ func (e *Element) SelectAttrValue(key, dflt string) string {
 	return dflt
 }
 
+// ChildProcInsts returns all processing instructions that are children of this element.
+func (e *Element) ChildProcInsts() []*ProcInst {
+	var procinsts []*ProcInst
+	for _, t := range e.Child {
+		if c, ok := t.(*ProcInst); ok {
+			procinsts = append(procinsts, c)
+		}
+	}
+	return procinsts
+}
+
 // ChildElements returns all elements that are children of this element.
 func (e *Element) ChildElements() []*Element {
 	var elements []*Element


### PR DESCRIPTION
After a long search for an easy way to process XML documents with Go I found this project and I am very thankful for it. For my project I am missing the possibility to select the processing instructions in the same way as the elements. Therefore I have made the appropriate adjustments in the source code and ask to take over these into the project.
With kind regards Andrej