### PR TITLE
Add read setting that maintains the default behavior of attribute parsing

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -1241,15 +1241,15 @@ func (e *Element) CreateAttr(key, value string) *Attr {
 
 // createAttr is a helper function that creates attributes.
 func (e *Element) createAttr(space, key, value string, parent *Element, preserveDups bool) *Attr {
-	for i, a := range e.Attr {
-		if space == a.Space && key == a.Key {
-			if preserveDups {
-				break
+	if !preserveDups {
+		for i, a := range e.Attr {
+			if space == a.Space && key == a.Key {
+				e.Attr[i].Value = value
+				return &e.Attr[i]
 			}
-			e.Attr[i].Value = value
-			return &e.Attr[i]
 		}
 	}
+
 	a := Attr{
 		Space:   space,
 		Key:     key,

--- a/etree_test.go
+++ b/etree_test.go
@@ -1394,3 +1394,64 @@ func TestReindexChildren(t *testing.T) {
 		}
 	}
 }
+
+func TestPreserveDuplicateAttrs(t *testing.T) {
+	s := `
+		<document attr="test" attr="test2"></document>
+	`
+	t.Run("Test DontOverwriteDoubledAttributes", func(t *testing.T) {
+		doc := NewDocument()
+
+		doc.ReadSettings = ReadSettings{
+			PreserveDuplicateAttrs: true,
+		}
+
+		err := doc.ReadFromString(s)
+		if err != nil {
+			t.Error("etree: unable to read document", err)
+		}
+
+		document := doc.FindElement("document")
+
+		if len(document.Attr) != 2 {
+			t.Error("etree: should have found 2 attributes")
+		}
+
+		if document.Attr[0].Value != "test" {
+			t.Errorf("etree: expected value test got %s", document.Attr[0].Value)
+		}
+
+		if document.Attr[0].Key != "attr" {
+			t.Errorf("etree: expected attribute key to be attr got %s", document.Attr[0].Key)
+		}
+
+		if document.Attr[1].Value != "test2" {
+			t.Errorf("etree: expected value test2 got %s", document.Attr[0].Value)
+		}
+
+		if document.Attr[1].Key != "attr" {
+			t.Errorf("etree: expected attribute key to be attr got %s", document.Attr[0].Key)
+		}
+
+	})
+
+	t.Run("Test Default Settings", func(t *testing.T) {
+		doc := NewDocument()
+
+		doc.ReadSettings = ReadSettings{
+			PreserveDuplicateAttrs: false,
+		}
+
+		err := doc.ReadFromString(s)
+		if err != nil {
+			t.Error("etree: unable to read document", err)
+		}
+
+		document := doc.FindElement("document")
+
+		if len(document.Attr) != 1 {
+			t.Error("etree: should have found 1 attribute")
+		}
+	})
+
+}

--- a/etree_test.go
+++ b/etree_test.go
@@ -1399,7 +1399,7 @@ func TestPreserveDuplicateAttrs(t *testing.T) {
 	s := `
 		<document attr="test" attr="test2"></document>
 	`
-	t.Run("Test DontOverwriteDoubledAttributes", func(t *testing.T) {
+	t.Run("Test PreserveDuplicateAttributes", func(t *testing.T) {
 		doc := NewDocument()
 
 		doc.ReadSettings = ReadSettings{
@@ -1452,6 +1452,14 @@ func TestPreserveDuplicateAttrs(t *testing.T) {
 		if len(document.Attr) != 1 {
 			t.Error("etree: should have found 1 attribute")
 		}
+		if document.Attr[0].Value != "test2" {
+			t.Errorf("etree: expected value test got %s", document.Attr[0].Value)
+		}
+
+		if document.Attr[0].Key != "attr" {
+			t.Errorf("etree: expected attribute key to be attr got %s", document.Attr[0].Key)
+		}
+
 	})
 
 }


### PR DESCRIPTION
Example Document:  

```
<document attr="test" attr="test2"></document>
```

Current Behavior: 

When parsing the attribute etree replaces the value of `attr` with `test2`

New Behavior:

When parsing an attribute, that already exists in the slice of attributes, we simply add another item to the slice.
That is also the default behavior of the `encoding/xml` std lib
This happens, when setting:

```go
doc.ReadSettings = ReadSettings{
	DontOverwriteDoubledAttributes: true,
}
```
