### PR TITLE
bug fix: InsertChildAt wrong index handling

### DIFF
--- a/etree.go
+++ b/etree.go
@@ -831,7 +831,7 @@ func (e *Element) InsertChildAt(index int, t Token) {
 	}
 
 	if t.Parent() != nil {
-		if t.Parent() == e && t.Index() > index {
+		if t.Parent() == e && t.Index() < index {
 			index--
 		}
 		t.Parent().RemoveChild(t)

--- a/etree_test.go
+++ b/etree_test.go
@@ -644,6 +644,34 @@ func TestInsertChild(t *testing.T) {
 	doc.Indent(2)
 	s4, _ := doc.WriteToString()
 	checkStrEq(t, s4, expected4)
+
+	year = doc.FindElement("//book/year")
+	book.InsertChildAt(0, year)
+
+	expected5 := `<book lang="en">
+  <year>1861</year>
+  <t:title>Great Expectations</t:title>
+  <author>Charles Dickens</author>
+</book>
+`
+
+	doc.Indent(2)
+	s5, _ := doc.WriteToString()
+	checkStrEq(t, s5, expected5)
+
+	author := doc.FindElement("//book/author")
+	year = doc.FindElement("//book/year")
+	book.InsertChildAt(author.Index(), year)
+
+	expected6 := `<book lang="en">
+  <t:title>Great Expectations</t:title>
+  <year>1861</year>
+  <author>Charles Dickens</author>
+</book>
+`
+	doc.Indent(2)
+	s6, _ := doc.WriteToString()
+	checkStrEq(t, s6, expected6)
 }
 
 func TestCdata(t *testing.T) {


### PR DESCRIPTION
I've encountered an issue when trying to **change order of children in list node**. For example, given the following XML configuration::
```
<BBUSWMSVC>
    <id>1</id>
    <activateTimeout>60</activateTimeout>
    <installationTimeout>300</installationTimeout>
</BBUSWMSVC>
```
I got etree.Element of `installationTimeout` and attempted to insert it before `activateTimeout`. The expected result is:
```
<BBUSWMSVC>
    <id>1</id>
    <installationTimeout>300</installationTimeout>
    <activateTimeout>60</activateTimeout>
</BBUSWMSVC>
```

However, for reasons explained below, I got:
```
<BBUSWMSVC>
    <installationTimeout>300</installationTimeout>
    <id>1</id>
    <activateTimeout>60</activateTimeout>
</BBUSWMSVC>
```

**Bug cause:** In examples above children array of `BBUSWMSVC` looks like this: `["\n", id, "\n", activateTimeout ,"\n", installationTimeout, "\n"]`. When we try to insert  `installationTimeout` (index 5) before `activateTimeout` (index 3) the condition t.Index() > index (5 > 3) happens and makes insertion index equal to 2. Final array looks like this: `["\n", id, installationTimeout, "\n", activateTimeout ,"\n", "\n"]`. We got off-by-one error, but we will not see difference between this and correct behaivior. 

When we are getting xml config in a single line:
```
<BBUSWMSVC><id>1</id><activateTimeout>60</activateTimeout><installationTimeout>300</installationTimeout></BBUSWMSVC>
```
Children array looks like this `[id, activateTimeout, installationTimeout]`. When trying to insert `installationTimeout` (index 2) before `activateTimeout` (index 1). Condition 2 >1 sets insertion index to **0**. So end result will look completly **incorrect**: `[installationTimeout, id, activateTimeout]`!!!

**Bug fix:** change condition `t.Index() < index`.

**Reason:** Let's use last example with array `[id, activateTimeout, installationTimeout]`.  When trying to insert `installationTimeout` (index 2) before `activateTimeout` (index 1). Condition 2 < 1 is false, so insertion index is still 1. End result will be correct: `[id, installationTimeout, activateTimeout]`.

And when, for example, we are trying to insert `id` (index 0) **before** `installationTimeout` (index 2) in array `[id, activateTimeout, installationTimeout]`. Firstly, `id` will be removed and all indexes after it will be decreased by 1, therefore `installationTimeout` will have index 1. Condition 0 < 2 is correct, so we will decrease insertion index by 1 and it becomes 1. As final result we will have correct array of children: `[activateTimeout, id, installationTimeout]`